### PR TITLE
Fix composite SRF (RETURNS TABLE) to correctly handle array returns

### DIFF
--- a/expected/function.out
+++ b/expected/function.out
@@ -239,6 +239,52 @@ SELECT * FROM set_of_unnamed_records() AS x(a int, b int);
  1 | 2
 (1 row)
 
+-- RETURNS TABLE with array of objects (composite SRF array return)
+CREATE FUNCTION returns_table_array() RETURNS TABLE(id int, name text) AS
+$$
+	return [
+		{ id: 1, name: 'Alice' },
+		{ id: 2, name: 'Bob' },
+		{ id: 3, name: 'Charlie' }
+	];
+$$
+LANGUAGE pljs;
+SELECT * FROM returns_table_array();
+ id |  name   
+----+---------
+  1 | Alice
+  2 | Bob
+  3 | Charlie
+(3 rows)
+
+-- RETURNS TABLE with single object
+CREATE FUNCTION returns_table_single() RETURNS TABLE(x int, y text) AS
+$$
+	return { x: 42, y: 'hello' };
+$$
+LANGUAGE pljs;
+SELECT * FROM returns_table_single();
+ x  |   y   
+----+-------
+ 42 | hello
+(1 row)
+
+-- RETURNS SETOF composite with array return
+CREATE FUNCTION set_of_rec_array() RETURNS SETOF rec AS
+$$
+	return [
+		{ i: 10, t: 'ten' },
+		{ i: 20, t: 'twenty' }
+	];
+$$
+LANGUAGE pljs;
+SELECT * FROM set_of_rec_array();
+ i  |   t    
+----+--------
+ 10 | ten
+ 20 | twenty
+(2 rows)
+
 -- execute with an array of arguments
 CREATE FUNCTION execute_with_array() RETURNS VOID AS
 $$

--- a/sql/function.sql
+++ b/sql/function.sql
@@ -148,6 +148,37 @@ SELECT * FROM set_of_unnamed_records() AS x(a int, c int);
 -- name counts and values match
 SELECT * FROM set_of_unnamed_records() AS x(a int, b int);
 
+-- RETURNS TABLE with array of objects (composite SRF array return)
+CREATE FUNCTION returns_table_array() RETURNS TABLE(id int, name text) AS
+$$
+	return [
+		{ id: 1, name: 'Alice' },
+		{ id: 2, name: 'Bob' },
+		{ id: 3, name: 'Charlie' }
+	];
+$$
+LANGUAGE pljs;
+SELECT * FROM returns_table_array();
+
+-- RETURNS TABLE with single object
+CREATE FUNCTION returns_table_single() RETURNS TABLE(x int, y text) AS
+$$
+	return { x: 42, y: 'hello' };
+$$
+LANGUAGE pljs;
+SELECT * FROM returns_table_single();
+
+-- RETURNS SETOF composite with array return
+CREATE FUNCTION set_of_rec_array() RETURNS SETOF rec AS
+$$
+	return [
+		{ i: 10, t: 'ten' },
+		{ i: 20, t: 'twenty' }
+	];
+$$
+LANGUAGE pljs;
+SELECT * FROM set_of_rec_array();
+
 -- execute with an array of arguments
 CREATE FUNCTION execute_with_array() RETURNS VOID AS
 $$

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1183,15 +1183,42 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
       bool is_null = false;
 
       if (state->is_composite) {
-        bool *nulls = (bool *)palloc0(sizeof(bool) * state->tuple_desc->natts);
+        // Handle composite (RETURNS TABLE / RETURNS SETOF record):
+        // JS can return a single object or an array of objects.
+        if (JS_IsArray(context->ctx, ret)) {
+          // Array of objects: iterate and put each as a row.
+          for (uint32_t i = 0; i < pljs_js_array_length(ret, context->ctx);
+               i++) {
+            JSValue val = JS_GetPropertyUint32(context->ctx, ret, i);
+            bool *nulls =
+                (bool *)palloc0(sizeof(bool) * state->tuple_desc->natts);
 
-        Datum *values = pljs_jsvalue_to_datums(NULL, argv[0], &nulls,
-                                               state->tuple_desc, context->ctx);
-        tuplestore_putvalues(state->tuple_store_state, state->tuple_desc,
-                             values, nulls);
+            Datum *values = pljs_jsvalue_to_datums(
+                NULL, val, &nulls, state->tuple_desc, context->ctx);
 
-        pfree(nulls);
-        pfree(values);
+            if (values != NULL) {
+              tuplestore_putvalues(state->tuple_store_state,
+                                   state->tuple_desc, values, nulls);
+              pfree(values);
+            }
+            pfree(nulls);
+            JS_FreeValue(context->ctx, val);
+          }
+        } else {
+          // Single object: put as one row.
+          bool *nulls =
+              (bool *)palloc0(sizeof(bool) * state->tuple_desc->natts);
+
+          Datum *values = pljs_jsvalue_to_datums(
+              NULL, ret, &nulls, state->tuple_desc, context->ctx);
+
+          if (values != NULL) {
+            tuplestore_putvalues(state->tuple_store_state,
+                                 state->tuple_desc, values, nulls);
+            pfree(values);
+          }
+          pfree(nulls);
+        }
       } else {
         if (JS_IsArray(context->ctx, ret)) {
           for (uint32_t i = 0; i < pljs_js_array_length(ret, context->ctx);
@@ -1203,6 +1230,7 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
                 context->ctx, NULL);
             tuplestore_putvalues(state->tuple_store_state, state->tuple_desc,
                                  &result, &is_null);
+            JS_FreeValue(context->ctx, val);
           }
         } else {
           if (!JS_IsUndefined(ret)) {


### PR DESCRIPTION
## Summary

Fixes a crash (segfault) and incorrect behavior when a pljs function with `RETURNS TABLE` or `RETURNS SETOF composite` returns a JavaScript array of objects.

**Three bugs fixed in `call_srf_function` (`src/pljs.c`):**

1. **Used `argv[0]` instead of `ret`** — The composite case read input arguments instead of the JS return value, causing all column values to be NULL.
2. **No array-of-objects handling** — Functions returning arrays like `[{id:1, name:'a'}, {id:2, name:'b'}]` were not iterated; only a single object was processed, leading to segfault.
3. **Missing NULL check before `pfree(values)`** — When `pljs_jsvalue_to_datums()` returns NULL, `pfree(NULL)` crashes.

Also fixed a minor memory leak: added `JS_FreeValue` for array elements in the non-composite scalar array case.

## Reproduction

```sql
-- This crashes PostgreSQL (segfault) on current main:
CREATE FUNCTION test_srf() RETURNS TABLE(id int, name text) AS $$
  return [{id: 1, name: 'Alice'}, {id: 2, name: 'Bob'}];
$$ LANGUAGE pljs;
SELECT * FROM test_srf();
```

## Test plan

- Added 3 regression tests to `sql/function.sql` and `expected/function.out`:
  - `RETURNS TABLE` with array of objects
  - `RETURNS TABLE` with single object return
  - `RETURNS SETOF rec` with array return
- All 20 existing regression tests continue to pass
- Added `Dockerfile.test` for easy build & test: `docker build -f Dockerfile.test -t pljs-test . && docker run --rm pljs-test`