### PR TITLE
Use PG_MODULE_MAGIC_EXT in PostgreSQL 18 and later

### DIFF
--- a/src/pljs.c
+++ b/src/pljs.c
@@ -20,7 +20,11 @@
 
 #include "pljs.h"
 
+#if PG_VERSION_NUM >= 180000
+PG_MODULE_MAGIC_EXT(.name = "pljs", .version = PLJS_VERSION);
+#else
 PG_MODULE_MAGIC;
+#endif
 
 PG_FUNCTION_INFO_V1(pljs_call_handler);
 PG_FUNCTION_INFO_V1(pljs_call_validator);


### PR DESCRIPTION
The `PG_MODULE_MAGIC_EXT` macro was added in PostgreSQL 18 and makes it possible to see which version of the library is actually loaded using `pg_get_loaded_modules()`.