### PR TITLE
Change PG_RETURN_NULL to PG_RETURN_VOID

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -924,7 +924,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
         *is_null = true;
       }
 
-      PG_RETURN_NULL();
+      PG_RETURN_VOID();
     }
   }
 


### PR DESCRIPTION
PG_RETURN_NULL() dereferences `fcinfo`, which causes a segfault in this code path.