### PR TITLE
- Fix mingw64/windows jsonb crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+*.a
 *.o
 *.so
+*.dll
 *.dylib
 results
 regression.diffs
@@ -7,6 +9,7 @@ regression.out
 
 .clangd
 .depend
+.deps
 docs/html
 docs/latex
 docs/xml

--- a/src/types.c
+++ b/src/types.c
@@ -1064,7 +1064,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
 #if JSONB_DIRECT_CONVERSION
     {
       Jsonb *obj = convert_object(argv[0], ctx);
-      PG_RETURN_JSONB_P(DatumGetJsonbP((unsigned long)obj));
+      PG_RETURN_JSONB_P(obj);
     }
 #else // JSONB_DIRECT_CONVERSION
     JSValue js = JS_JSONStringify(ctx, argv[0], JS_UNDEFINED, JS_UNDEFINED);


### PR DESCRIPTION
- Add windows artifacts to .gitignore

Main issue is unsigned long in windows is 32-bit so was being truncated No need for this anyway since PG_RETURN_JSONB_P already works directly without going thru DatumGetJsonbP
Closes #20