### PR TITLE
Fix NULL dereference in pljs_jsvalue_to_datum when fcinfo is NULL (against 1.1.0-dev)

### DIFF
--- a/src/types.c
+++ b/src/types.c
@@ -924,7 +924,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
         *is_null = true;
       }
 
-      PG_RETURN_NULL();
+      return (Datum)0;
     }
   }
 


### PR DESCRIPTION
pljs_jsvalue_to_datum() takes an optional FunctionCallInfo fcinfo, and its own NULL/undefined-value branch is written as an if(fcinfo)/else specifically to handle the fcinfo == NULL case (setting *is_null via the out-parameter instead). But the else branch called PG_RETURN_NULL(), which unconditionally expands to code that dereferences fcinfo -- exactly the pointer that branch exists because it's NULL. Any caller that legitimately passes fcinfo == NULL (this function is called from outside a SQL-function-call context in more than one place already) and hits this path crashes.

Fixed by returning (Datum)0 directly in that branch, matching what PG_RETURN_NULL() does other than the fcinfo->isnull write it can't safely make here.

Verified with a full `make installcheck` run (all existing regression tests still pass) and a clean build with no new warnings.