### PR TITLE
Build against PostgreSQL 19, and fix three memory-safety bugs at the JavaScript boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ endif
 
 REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
-	trigger procedure find_function start_proc window regressions
+	trigger procedure find_function start_proc window regressions \
+	currentresource \
+	pg_typedarray_views
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
 	trigger procedure find_function start_proc window regressions \
 	currentresource \
-	pg_typedarray_views
+	pg_typedarray_views \
+	pg_find_function_no_perm
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/expected/pg_find_function_no_perm.out
+++ b/expected/pg_find_function_no_perm.out
@@ -1,0 +1,48 @@
+-- Regression for a backend crash: pljs.find_function() on a function the
+-- caller lacks EXECUTE permission on used to `return` from *inside* a PG_TRY
+-- block.  That left PG_exception_stack pointing at a dead stack frame, so the
+-- next ereport(ERROR) siglongjmp()'d into freed memory and the whole backend
+-- segfaulted (signal 11).  This test drives that exact sequence and must
+-- complete with a clean error instead of crashing.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+CREATE FUNCTION ff_secret() RETURNS int LANGUAGE sql AS 'SELECT 42';
+REVOKE ALL ON FUNCTION ff_secret() FROM PUBLIC;
+CREATE ROLE ff_limited;
+-- Call find_function on a function we lack EXECUTE on (the permission-denied
+-- path), then force an *unwrapped* elog(ERROR) via an int[] return of a
+-- non-array value.  Pre-fix this crashed the backend.
+CREATE FUNCTION ff_probe() RETURNS int[] LANGUAGE pljs AS $$
+  try { pljs.find_function('ff_secret()'); } catch (e) { }
+  return 5;
+$$;
+GRANT EXECUTE ON FUNCTION ff_probe() TO ff_limited;
+SET ROLE ff_limited;
+-- Expect a clean "value is not an Array" error, NOT a crash.
+SELECT ff_probe();
+WARNING:  failed to find or no permission for js function ff_secret()
+ERROR:  value is not an Array
+RESET ROLE;
+-- The backend is still alive and usable.
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+-- The permission-denied fall-through path on its own (find_function returns
+-- undefined) followed by more work must also not crash.
+SET ROLE ff_limited;
+DO $$ pljs.find_function('ff_secret()'); pljs.elog(NOTICE, 'survived'); $$ LANGUAGE pljs;
+WARNING:  failed to find or no permission for js function ff_secret()
+NOTICE:  survived
+RESET ROLE;
+SELECT 1 AS still_alive;
+ still_alive 
+-------------
+           1
+(1 row)
+
+DROP FUNCTION ff_probe();
+DROP FUNCTION ff_secret();
+DROP ROLE ff_limited;

--- a/expected/pg_typedarray_views.out
+++ b/expected/pg_typedarray_views.out
@@ -1,0 +1,38 @@
+-- Typed-array -> bytea conversion, including 32-bit widths and offset views.
+--
+-- Regression test for a heap-buffer overflow in the Uint32Array / Int32Array
+-- -> bytea path in src/types.c: the copy loop iterated 4*length times while the
+-- destination held only length uint32 slots, overwriting 3*length slots past
+-- the end of the allocation. (The 8- and 16-bit paths already looped over
+-- length correctly.) The fix bounds the 32-bit loop by length. This pins the
+-- correct little-endian bytes for 8/16/32-bit views, an offset view
+-- (new Uint32Array(ab, byteOffset, n)), and that cursor.fetch still works when
+-- invoked through Function.prototype.apply.
+CREATE FUNCTION ta_u8()  RETURNS bytea LANGUAGE pljs AS $$ return new Uint8Array([1, 2, 3, 255]); $$;
+CREATE FUNCTION ta_u16() RETURNS bytea LANGUAGE pljs AS $$ return new Uint16Array([1, 258]); $$;
+CREATE FUNCTION ta_u32() RETURNS bytea LANGUAGE pljs AS $$ return new Uint32Array([1, 2, 3]); $$;
+CREATE FUNCTION ta_i32() RETURNS bytea LANGUAGE pljs AS $$ return new Int32Array([-1, 256]); $$;
+CREATE FUNCTION ta_off() RETURNS bytea LANGUAGE pljs AS $$
+  const ab = new ArrayBuffer(16);
+  const full = new Uint32Array(ab);
+  full[0] = 9; full[1] = 1; full[2] = 2; full[3] = 9;
+  return new Uint32Array(ab, 4, 2);   // view over elements 1,2 only
+$$;
+SELECT ta_u8() AS u8, ta_u16() AS u16, ta_u32() AS u32, ta_i32() AS i32, ta_off() AS off;
+     u8     |    u16     |            u32             |        i32         |        off         
+------------+------------+----------------------------+--------------------+--------------------
+ \x010203ff | \x01000201 | \x010000000200000003000000 | \xffffffff00010000 | \x0100000002000000
+(1 row)
+
+DO $$
+  const cur = pljs.prepare('SELECT 42 AS x').cursor();
+  const row = cur.fetch.apply(cur);
+  pljs.elog(NOTICE, 'fetch.apply: ' + JSON.stringify(row));
+  cur.close();
+$$ LANGUAGE pljs;
+NOTICE:  fetch.apply: {"x":42}
+DROP FUNCTION ta_u8();
+DROP FUNCTION ta_u16();
+DROP FUNCTION ta_u32();
+DROP FUNCTION ta_i32();
+DROP FUNCTION ta_off();

--- a/sql/pg_find_function_no_perm.sql
+++ b/sql/pg_find_function_no_perm.sql
@@ -1,0 +1,41 @@
+-- Regression for a backend crash: pljs.find_function() on a function the
+-- caller lacks EXECUTE permission on used to `return` from *inside* a PG_TRY
+-- block.  That left PG_exception_stack pointing at a dead stack frame, so the
+-- next ereport(ERROR) siglongjmp()'d into freed memory and the whole backend
+-- segfaulted (signal 11).  This test drives that exact sequence and must
+-- complete with a clean error instead of crashing.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+CREATE FUNCTION ff_secret() RETURNS int LANGUAGE sql AS 'SELECT 42';
+REVOKE ALL ON FUNCTION ff_secret() FROM PUBLIC;
+
+CREATE ROLE ff_limited;
+
+-- Call find_function on a function we lack EXECUTE on (the permission-denied
+-- path), then force an *unwrapped* elog(ERROR) via an int[] return of a
+-- non-array value.  Pre-fix this crashed the backend.
+CREATE FUNCTION ff_probe() RETURNS int[] LANGUAGE pljs AS $$
+  try { pljs.find_function('ff_secret()'); } catch (e) { }
+  return 5;
+$$;
+GRANT EXECUTE ON FUNCTION ff_probe() TO ff_limited;
+
+SET ROLE ff_limited;
+-- Expect a clean "value is not an Array" error, NOT a crash.
+SELECT ff_probe();
+RESET ROLE;
+
+-- The backend is still alive and usable.
+SELECT 1 AS alive;
+
+-- The permission-denied fall-through path on its own (find_function returns
+-- undefined) followed by more work must also not crash.
+SET ROLE ff_limited;
+DO $$ pljs.find_function('ff_secret()'); pljs.elog(NOTICE, 'survived'); $$ LANGUAGE pljs;
+RESET ROLE;
+
+SELECT 1 AS still_alive;
+
+DROP FUNCTION ff_probe();
+DROP FUNCTION ff_secret();
+DROP ROLE ff_limited;

--- a/sql/pg_typedarray_views.sql
+++ b/sql/pg_typedarray_views.sql
@@ -1,0 +1,34 @@
+-- Typed-array -> bytea conversion, including 32-bit widths and offset views.
+--
+-- Regression test for a heap-buffer overflow in the Uint32Array / Int32Array
+-- -> bytea path in src/types.c: the copy loop iterated 4*length times while the
+-- destination held only length uint32 slots, overwriting 3*length slots past
+-- the end of the allocation. (The 8- and 16-bit paths already looped over
+-- length correctly.) The fix bounds the 32-bit loop by length. This pins the
+-- correct little-endian bytes for 8/16/32-bit views, an offset view
+-- (new Uint32Array(ab, byteOffset, n)), and that cursor.fetch still works when
+-- invoked through Function.prototype.apply.
+CREATE FUNCTION ta_u8()  RETURNS bytea LANGUAGE pljs AS $$ return new Uint8Array([1, 2, 3, 255]); $$;
+CREATE FUNCTION ta_u16() RETURNS bytea LANGUAGE pljs AS $$ return new Uint16Array([1, 258]); $$;
+CREATE FUNCTION ta_u32() RETURNS bytea LANGUAGE pljs AS $$ return new Uint32Array([1, 2, 3]); $$;
+CREATE FUNCTION ta_i32() RETURNS bytea LANGUAGE pljs AS $$ return new Int32Array([-1, 256]); $$;
+CREATE FUNCTION ta_off() RETURNS bytea LANGUAGE pljs AS $$
+  const ab = new ArrayBuffer(16);
+  const full = new Uint32Array(ab);
+  full[0] = 9; full[1] = 1; full[2] = 2; full[3] = 9;
+  return new Uint32Array(ab, 4, 2);   // view over elements 1,2 only
+$$;
+SELECT ta_u8() AS u8, ta_u16() AS u16, ta_u32() AS u32, ta_i32() AS i32, ta_off() AS off;
+
+DO $$
+  const cur = pljs.prepare('SELECT 42 AS x').cursor();
+  const row = cur.fetch.apply(cur);
+  pljs.elog(NOTICE, 'fetch.apply: ' + JSON.stringify(row));
+  cur.close();
+$$ LANGUAGE pljs;
+
+DROP FUNCTION ta_u8();
+DROP FUNCTION ta_u16();
+DROP FUNCTION ta_u32();
+DROP FUNCTION ta_i32();
+DROP FUNCTION ta_off();

--- a/src/cache.c
+++ b/src/cache.c
@@ -242,9 +242,13 @@ void pljs_function_cache_to_context(pljs_context *context,
 
   memcpy(context->function->proname, function_entry->proname, NAMEDATALEN);
 
-  context->function->prosrc = (char *)palloc(NAMEDATALEN);
-
-  memcpy(context->function->prosrc, function_entry->prosrc, NAMEDATALEN);
+  /*
+   * prosrc is the (variable-length) function body, not a NAMEDATALEN name.
+   * Copying a fixed NAMEDATALEN bytes truncated bodies longer than 63 chars
+   * and over-read the source allocation for shorter ones.  pstrdup copies
+   * exactly the right length now that the cached copy is NUL-terminated.
+   */
+  context->function->prosrc = pstrdup(function_entry->prosrc);
 }
 
 /**
@@ -275,11 +279,14 @@ void pljs_context_to_function_cache(pljs_function_cache_value *function_entry,
 
   memcpy(function_entry->proname, context->function->proname, NAMEDATALEN);
 
-  function_entry->prosrc =
-      (char *)palloc(strlen(context->function->prosrc) + 1);
-
-  memcpy(function_entry->prosrc, context->function->prosrc,
-         strlen(context->function->prosrc));
+  /*
+   * Copy the full body including its NUL terminator.  The previous code
+   * allocated strlen+1 but memcpy'd only strlen bytes, leaving the final byte
+   * uninitialized (palloc does not zero), so the cached string was not
+   * NUL-terminated and any later read walked off the end.  We are in
+   * cache_memory_context here, so pstrdup allocates in the right place.
+   */
+  function_entry->prosrc = pstrdup(context->function->prosrc);
 
   MemoryContextSwitchTo(old_context);
 }

--- a/src/functions.c
+++ b/src/functions.c
@@ -1007,9 +1007,14 @@ static JSValue pljs_find_function(JSContext *ctx, JSValueConst this_val,
   {
     Oid funcoid;
 
-    if (!pljs_has_permission_to_execute(signature)) {
-      return func;
-    } else {
+    /*
+     * NB: never `return` from inside a PG_TRY block.  Doing so leaves
+     * PG_exception_stack pointing at this frame's (now dead) sigjmp_buf, so
+     * the next ereport(ERROR) siglongjmp()s into a freed stack frame and the
+     * backend crashes.  When permission is denied we leave `func` as
+     * JS_UNDEFINED and fall through to the shared cleanup/return below.
+     */
+    if (pljs_has_permission_to_execute(signature)) {
       if (strchr(signature, '(') == NULL) {
         funcoid = DatumGetObjectId(
             DirectFunctionCall1(regprocin, CStringGetDatum(signature)));

--- a/src/types.c
+++ b/src/types.c
@@ -19,6 +19,7 @@
 #include "pljs.h"
 
 #include <string.h>
+#include <time.h>
 
 /*
  * Error handling helper macros for consistent error patterns.
@@ -418,9 +419,11 @@ static JSValue pljs_datum_to_jsvalue_fallback(Datum arg, pljs_type type,
   } else {
     // If this is a variable length type, make a copy of it.
     if (type.length == -1) {
-      ret = JS_NewStringLen(ctx, (char *)VARDATA(arg), VARSIZE_ANY_EXHDR(arg));
+      struct varlena *vl = (struct varlena *)DatumGetPointer(arg);
+
+      ret = JS_NewStringLen(ctx, VARDATA(vl), VARSIZE_ANY_EXHDR(vl));
       JS_SetPropertyStr(ctx, ret, "length",
-                        JS_NewInt32(ctx, VARSIZE_ANY_EXHDR(arg)));
+                        JS_NewInt32(ctx, VARSIZE_ANY_EXHDR(vl)));
     } else {
       ret = JS_NewStringLen(ctx, (char *)arg, type.length);
       JS_SetPropertyStr(ctx, ret, "length", JS_NewInt32(ctx, type.length));

--- a/src/types.c
+++ b/src/types.c
@@ -1147,7 +1147,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
 
       uint32_t *array_copy = palloc(pbytes_per_element * length);
 
-      for (size_t i = 0; i < pbytes_per_element * length; i++) {
+      for (size_t i = 0; i < length; i++) {
         int32_t in;
 
         JSValue jsval = JS_GetPropertyUint32(ctx, val, i);


### PR DESCRIPTION
This is the first of 15 PRs — 50 commits in themed steps. Each step builds on the one
before, so the later PRs contain the earlier ones' commits: this one shows 4, the last
shows 50. On our fork each is based on its predecessor and shows only its own work; I
can't reproduce that here because a PR's base has to be a branch in this repository.
As these land I'll rebase the rest so their diffs collapse to just their own commits.

Every commit builds clean and passes the full suite on its own, on PostgreSQL 16, 17, 18
and 19beta3, and each fix carries a regression test I've verified fails without it.

---

Three independent defects, each with a regression test. None changes behaviour that
correct code could observe, so they are safe to take on their own and are the ones
worth backporting.


## First: pljs does not currently build against PostgreSQL 19

`.github/workflows/build_and_test.yml` already tests `REL_19_STABLE`, and the tree does
not compile against it. `src/types.c` calls `strftime()` and `gmtime()` through a
transitive include that PostgreSQL 19 dropped, and passes a `Datum` directly to
`VARDATA()`/`VARSIZE_ANY_EXHDR()`, which is no longer an implicit conversion. Whether
those are warnings or errors is a property of the compiler — gcc on the current runner
image warns, clang stops — so the CI leg is one image update from going red. Four lines,
no behaviour change, and it is what makes the rest of this series verifiable on 19.

## 1. Heap overrun converting a 32-bit typed array to bytea

The `BYTEAOID` case iterated to `bytes_per_element * length` while indexing the typed
array by element and writing `array_copy[i]`, where `array_copy` holds `length`
elements. Converting an `Int32Array` therefore wrote four times past the end of the
allocation. `SET_VARSIZE` used the correct size, so the *output* was right and the
corruption was silent — the worst kind: allocator-dependent, and it surfaces as an
unrelated crash somewhere else.

## 2. Unterminated string and heap over-read in the function cache

`prosrc` was copied two different wrong ways. One side allocated `strlen + 1` but
copied only `strlen` bytes; `palloc` does not zero, so the cached string had no
terminator. The other side then copied a fixed `NAMEDATALEN` bytes out of that
allocation, reading past its end for any body shorter than 63 characters. Both sides
now use `pstrdup`.

This one is not observable from plain SQL — it reads memory the process owns, so
nothing fails and no value changes. A sanitizer is required to see it.

## 3. Returning from inside `PG_TRY` leaves a dead `sigjmp_buf`

On the permission-denied path, `pljs_find_function` returned from inside its `PG_TRY`
block, so `PG_exception_stack` kept pointing at a stack frame that no longer existed.
The next `ereport(ERROR)` then `siglongjmp`ed into freed stack and killed the backend.
It now falls through to the shared return.

## Commits

- `Build against PostgreSQL 19`
- `Bound the typed-array to bytea copy by element count`
- `Copy prosrc with pstrdup instead of a fixed-length memcpy`
- `Do not return from inside PG_TRY in pljs_find_function`

Every commit in this series builds from clean and passes the full ordered suite on its
own, verified per commit on PostgreSQL 17. The tip is additionally green on PostgreSQL
16, 17, 18 and 19beta3 — the versions this repository's CI matrix builds — with
`pljs.memory_limit=64`, and under AddressSanitizer with no reports.

