### PR TITLE
Build a name bind as a NameData, not as text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_composite_null_datum \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate \
-	pg_targeted_invalidation
+	pg_targeted_invalidation \
+	pg_number_string_parse
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate \
 	pg_targeted_invalidation \
-	pg_number_string_parse
+	pg_number_string_parse \
+	pg_name_bind
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ endif
 
 REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
-	trigger procedure find_function start_proc window regressions
+	trigger procedure find_function start_proc window regressions \
+	currentresource \
+	pg_typedarray_views
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
 	trigger procedure find_function start_proc window regressions \
 	pg_flush_error_state pg_spi_freetuptable \
+	pg_prepared_plan_lifetime \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm pg_cursor_error_recovery \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_record_no_column_list \
+	pg_return_next_error_frames \
 	pg_error_envelope_fields \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_nested_stack_anchor \
 	pg_composite_null_datum \
 	pg_error_sqlstate \
-	pg_plan_argcount_sqlstate
+	pg_plan_argcount_sqlstate \
+	pg_targeted_invalidation
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
+	pg_memory_limit_set \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_cursor_plan_lifetime \

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_return_next_error_frames \
 	pg_error_envelope_fields \
 	pg_validator \
+	pg_cross_backend_invalidation \
 	pg_find_function_refcount \
 	pg_trigger_spi \
 	pg_nested_stack_anchor \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_return_next_error_frames \
 	pg_error_envelope_fields \
 	pg_find_function_refcount \
+	pg_trigger_spi \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
 	trigger procedure find_function start_proc window regressions \
-	pg_flush_error_state \
+	pg_flush_error_state pg_spi_freetuptable \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm \

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_typedarray_views \
 	pg_find_function_no_perm \
 	pg_column_name_mismatch \
+	pg_record_no_column_list \
 	pg_error_envelope_fields \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_object_keys_leak \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
+	pg_record_column_leak \
 	pg_cursor_plan_lifetime \
 	pg_record_no_column_list \
 	pg_return_next_error_frames \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm \
+	pg_error_envelope_fields \
 	pg_error_sqlstate
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ endif
 REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
 	trigger procedure find_function start_proc window regressions \
+	pg_flush_error_state \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_flush_error_state \
 	currentresource \
 	pg_typedarray_views \
-	pg_find_function_no_perm
+	pg_find_function_no_perm \
+	pg_error_sqlstate
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm \
+	pg_column_name_mismatch \
 	pg_error_envelope_fields \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_typedarray_views \
 	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
 	pg_memory_limit_set \
+	pg_param_plan_leak \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_cursor_plan_lifetime \

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_record_column_leak \
+	pg_param_plan_error_leak \
 	pg_cursor_plan_lifetime \
 	pg_record_no_column_list \
 	pg_return_next_error_frames \

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_record_no_column_list \
 	pg_return_next_error_frames \
 	pg_error_envelope_fields \
+	pg_find_function_refcount \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
 	trigger procedure find_function start_proc window regressions \
 	currentresource \
-	pg_typedarray_views
+	pg_typedarray_views \
+	pg_find_function_no_perm
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_prepared_plan_lifetime \
 	currentresource \
 	pg_typedarray_views \
-	pg_find_function_no_perm pg_cursor_error_recovery \
+	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_record_no_column_list \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
-	pg_memory_limit_set \
+	pg_cancellation pg_memory_limit_set \
 	pg_param_plan_leak \
 	pg_object_keys_leak \
 	pg_errordata_stack \

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
 	pg_memory_limit_set \
 	pg_param_plan_leak \
+	pg_object_keys_leak \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_cursor_plan_lifetime \

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_record_no_column_list \
 	pg_return_next_error_frames \
 	pg_error_envelope_fields \
+	pg_validator \
 	pg_find_function_refcount \
 	pg_trigger_spi \
 	pg_nested_stack_anchor \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm pg_cursor_error_recovery \
+	pg_errordata_stack \
 	pg_column_name_mismatch \
 	pg_record_no_column_list \
 	pg_error_envelope_fields \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_flush_error_state pg_spi_freetuptable \
 	currentresource \
 	pg_typedarray_views \
-	pg_find_function_no_perm \
+	pg_find_function_no_perm pg_cursor_error_recovery \
 	pg_column_name_mismatch \
 	pg_record_no_column_list \
 	pg_error_envelope_fields \

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_typedarray_views \
 	pg_find_function_no_perm \
 	pg_error_envelope_fields \
-	pg_error_sqlstate
+	pg_error_sqlstate \
+	pg_plan_argcount_sqlstate
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	currentresource \
 	pg_typedarray_views \
 	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
-	pg_cancellation pg_memory_limit_set \
+	pg_cancellation pg_stack_depth pg_memory_limit_set \
 	pg_param_plan_leak \
 	pg_object_keys_leak \
 	pg_errordata_stack \

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_param_plan_leak \
 	pg_object_keys_leak \
 	pg_errordata_stack \
+	pg_return_next_null_row \
 	pg_column_name_mismatch \
 	pg_record_column_leak \
 	pg_param_plan_error_leak \

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_error_envelope_fields \
 	pg_find_function_refcount \
 	pg_trigger_spi \
+	pg_composite_null_datum \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_find_function_no_perm pg_cursor_error_recovery pg_prepared_plan_gc \
 	pg_errordata_stack \
 	pg_column_name_mismatch \
+	pg_cursor_plan_lifetime \
 	pg_record_no_column_list \
 	pg_return_next_error_frames \
 	pg_error_envelope_fields \

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ REGRESS = init-extension function json jsonb json_conv types bytea context \
 	pg_error_envelope_fields \
 	pg_find_function_refcount \
 	pg_trigger_spi \
+	pg_nested_stack_anchor \
 	pg_composite_null_datum \
 	pg_error_sqlstate \
 	pg_plan_argcount_sqlstate

--- a/expected/array_spread.out
+++ b/expected/array_spread.out
@@ -4,7 +4,7 @@ set pljs.memory_limit = '64';
 do $$ Object.prototype [Symbol.iterator] = function() { return { next:() => this } };
 [...({})];
 $$ language pljs;
-ERROR:  execution error
+ERROR:  out of memory
 DETAIL:  InternalError: out of memory
     at <anonymous> (<function>:2:1)
     at <eval> (<function>:3:3)

--- a/expected/find_function.out
+++ b/expected/find_function.out
@@ -32,12 +32,12 @@ SELECT caller(10, 2);
 (1 row)
 
 SELECT caller(10, 3);
-ERROR:  execution error
+ERROR:  javascript function is not found for "sqlf"
 DETAIL:  Error: javascript function is not found for "sqlf"
     at caller (<function>:9:30)
 
 SELECT caller(10, 4);
-ERROR:  execution error
+ERROR:  javascript function is not found for "callee(int, int)"
 DETAIL:  Error: javascript function is not found for "callee(int, int)"
     at caller (<function>:11:30)
 

--- a/expected/find_function.out
+++ b/expected/find_function.out
@@ -37,8 +37,8 @@ DETAIL:  Error: javascript function is not found for "sqlf"
     at caller (<function>:9:30)
 
 SELECT caller(10, 4);
-ERROR:  javascript function is not found for "callee(int, int)"
-DETAIL:  Error: javascript function is not found for "callee(int, int)"
+ERROR:  function "callee(int, int)" does not exist
+DETAIL:  Error: function "callee(int, int)" does not exist
     at caller (<function>:11:30)
 
 SELECT caller(10, 5);

--- a/expected/function.out
+++ b/expected/function.out
@@ -166,7 +166,7 @@ $$
 $$
 LANGUAGE pljs;
 SELECT * FROM set_of_record_but_non_obj();
-ERROR:  execution error
+ERROR:  argument must be an object
 DETAIL:  Error: argument must be an object
     at set_of_record_but_non_obj (<function>:3:18)
 
@@ -228,7 +228,7 @@ SELECT * FROM set_of_unnamed_records() AS x(a int);
 
 -- field names mismatch
 SELECT * FROM set_of_unnamed_records() AS x(a int, c int);
-ERROR:  execution error
+ERROR:  field name / property name mismatch
 DETAIL:  Error: field name / property name mismatch
     at set_of_unnamed_records (<function>:3:21)
 
@@ -311,7 +311,7 @@ SELECT * FROM execute_without_array();
 
 CREATE FUNCTION test_sql_error() RETURNS void AS $$ pljs.execute("ERROR") $$ LANGUAGE pljs;
 SELECT test_sql_error();
-ERROR:  execution error
+ERROR:  syntax error at or near "ERROR"
 DETAIL:  Error: syntax error at or near "ERROR"
     at test_sql_error (<function>:2:14)
 
@@ -349,7 +349,7 @@ pljs.subtransaction(function(){
 });
 $$ LANGUAGE pljs;
 SELECT test_subtransaction_throw();
-ERROR:  execution error
+ERROR:  division by zero
 DETAIL:  Error: division by zero
     at <anonymous> (<function>:5:14)
     at subtransaction (native)

--- a/expected/function.out
+++ b/expected/function.out
@@ -228,8 +228,8 @@ SELECT * FROM set_of_unnamed_records() AS x(a int);
 
 -- field names mismatch
 SELECT * FROM set_of_unnamed_records() AS x(a int, c int);
-ERROR:  field name / property name mismatch
-DETAIL:  Error: field name / property name mismatch
+ERROR:  return_next: result column "c" has no matching property (object has: a, b; property names are case sensitive)
+DETAIL:  Error: return_next: result column "c" has no matching property (object has: a, b; property names are case sensitive)
     at set_of_unnamed_records (<function>:3:21)
 
 -- name counts and values match

--- a/expected/memory_limits.out
+++ b/expected/memory_limits.out
@@ -11,7 +11,7 @@ do $$
   const limit = pljs.execute(`select setting from pg_settings where name = $1`, ['pljs.memory_limit'])[0].setting;
   const a = new ArrayBuffer(limit*1024*1024);
 $$ language pljs;
-ERROR:  execution error
+ERROR:  out of memory
 DETAIL:  InternalError: out of memory
     at <anonymous> (<function>:3:28)
     at <eval> (<function>:4:3)
@@ -24,5 +24,5 @@ do $$
     s.push(new ArrayBuffer(63)) // small non-aligned allocations
   }
 $$ language pljs;
-ERROR:  execution error
+ERROR:  out of memory
 DETAIL:  out of memory

--- a/expected/pg_cancellation.out
+++ b/expected/pg_cancellation.out
@@ -1,0 +1,45 @@
+-- Regression: pljs must honor query cancellation / statement_timeout.
+--
+-- Previously _PG_init() installed its own signal(SIGINT/SIGTERM/SIGABRT)
+-- handlers, clobbering PostgreSQL's own signal handling for the whole backend,
+-- and the QuickJS interrupt handler only consulted pljs's private
+-- os_pending_signals bitmask.  statement_timeout is delivered via SIGALRM ->
+-- QueryCancelPending, which that bitmask never saw, so a runaway JS loop could
+-- not be cancelled and the backend hung forever.  The interrupt handler now
+-- reads QueryCancelPending/ProcDiePending directly, and each caller re-raises
+-- the real error via CHECK_FOR_INTERRUPTS() once QuickJS has unwound to an
+-- exception.  These tests must complete (with a cancel error) instead of
+-- hanging.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- A runaway loop in an anonymous DO block (call_anonymous_function path) must
+-- be cancelled by statement_timeout.
+SET statement_timeout = '400ms';
+DO $$ var x = 0; while (true) { x++; } $$ LANGUAGE pljs;
+ERROR:  canceling statement due to statement timeout
+RESET statement_timeout;
+-- ... and in a regular function (call_function path).
+CREATE FUNCTION spin() RETURNS int LANGUAGE pljs AS $$
+  var x = 0;
+  while (true) { x++; }
+  return x;
+$$;
+SET statement_timeout = '400ms';
+SELECT spin();
+ERROR:  canceling statement due to statement timeout
+RESET statement_timeout;
+-- The backend survived both cancellations and is still usable.
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+-- A normal JS error must NOT be masked by the interrupt check (no cancel is
+-- pending, so CHECK_FOR_INTERRUPTS() is a no-op and the real JS error surfaces).
+DO $$
+  try { throw new Error('plain error'); }
+  catch (e) { pljs.elog(NOTICE, 'caught: ' + e.message); }
+$$ LANGUAGE pljs;
+NOTICE:  caught: plain error
+DROP FUNCTION spin();

--- a/expected/pg_column_name_mismatch.out
+++ b/expected/pg_column_name_mismatch.out
@@ -1,0 +1,78 @@
+-- The column/property mismatch error says which column and what was offered.
+--
+-- return_next() on a composite set raised a bare "field name / property name
+-- mismatch", which gave the function author nothing to act on: not which column
+-- was missing, and not what the object actually contained.  For a wide RETURNS
+-- TABLE that meant reading the whole declaration against the whole object by eye.
+--
+-- The overwhelmingly common cause is a case difference -- JavaScript property
+-- names are case sensitive while PostgreSQL folds unquoted identifiers to lower
+-- case, so a `MixedCol` key never matches a `mixedcol` column, and the two look
+-- identical at a glance.  Naming both sides makes that immediate.
+--
+-- Note this deliberately stays an error rather than filling the column with NULL.
+-- NULL-filling would make a typo'd or wrong-case key silently produce a NULL
+-- column, turning a loud, fixable mistake into exactly the kind of silent data
+-- loss the rest of these fixes exist to remove.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- 1) a genuinely missing column names itself and lists what was provided.
+CREATE FUNCTION cnm_missing() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({a: 1});
+$$;
+SELECT * FROM cnm_missing();
+ERROR:  return_next: result column "b" has no matching property (object has: a; property names are case sensitive)
+DETAIL:  Error: return_next: result column "b" has no matching property (object has: a; property names are case sensitive)
+    at cnm_missing (<function>:3:19)
+
+-- 2) the case-mismatch case, which is what this is really for.
+CREATE FUNCTION cnm_case() RETURNS TABLE(mixedcol int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({MixedCol: 7, b: 'x'});
+$$;
+SELECT * FROM cnm_case();
+ERROR:  return_next: result column "mixedcol" has no matching property (object has: MixedCol, b; property names are case sensitive)
+DETAIL:  Error: return_next: result column "mixedcol" has no matching property (object has: MixedCol, b; property names are case sensitive)
+    at cnm_case (<function>:3:19)
+
+-- 3) an object with no properties at all.
+CREATE FUNCTION cnm_empty() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({});
+$$;
+SELECT * FROM cnm_empty();
+ERROR:  return_next: result column "a" has no matching property (object has: no properties; property names are case sensitive)
+DETAIL:  Error: return_next: result column "a" has no matching property (object has: no properties; property names are case sensitive)
+    at cnm_empty (<function>:3:19)
+
+-- 4) the first missing column is the one reported, even when several are absent.
+CREATE FUNCTION cnm_several() RETURNS TABLE(alpha int, beta text, gamma int)
+LANGUAGE pljs AS $$
+  pljs.return_next({beta: 'only this one'});
+$$;
+SELECT * FROM cnm_several();
+ERROR:  return_next: result column "alpha" has no matching property (object has: beta; property names are case sensitive)
+DETAIL:  Error: return_next: result column "alpha" has no matching property (object has: beta; property names are case sensitive)
+    at cnm_several (<function>:3:19)
+
+-- 5) the error is catchable in JavaScript and carries the detail.
+DO $$
+  try {
+    pljs.execute('SELECT * FROM cnm_case()');
+    pljs.elog(NOTICE, 'unexpectedly succeeded');
+  } catch (e) {
+    pljs.elog(NOTICE, 'names the column: ' + (e.message.indexOf('mixedcol') >= 0));
+    pljs.elog(NOTICE, 'lists the keys: ' + (e.message.indexOf('MixedCol') >= 0));
+  }
+$$ LANGUAGE pljs;
+NOTICE:  names the column: true
+NOTICE:  lists the keys: true
+-- 6) a complete object still works, and extra properties remain ignored.
+CREATE FUNCTION cnm_ok() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({a: 1, b: 'x', extra: 'ignored'});
+$$;
+SELECT a, b FROM cnm_ok();
+ a | b 
+---+---
+ 1 | x
+(1 row)
+
+DROP FUNCTION cnm_missing, cnm_case, cnm_empty, cnm_several, cnm_ok;

--- a/expected/pg_column_name_mismatch.out
+++ b/expected/pg_column_name_mismatch.out
@@ -76,3 +76,17 @@ SELECT a, b FROM cnm_ok();
 (1 row)
 
 DROP FUNCTION cnm_missing, cnm_case, cnm_empty, cnm_several, cnm_ok;
+-- The provided-key list is capped.  An object with thousands of properties would
+-- otherwise put every name into the message, which lands in the server log as
+-- well as the client; ten names plus the total is enough to spot a typo.
+CREATE FUNCTION cnm_many() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  const row = {};
+  for (let i = 0; i < 500; i++) row['prop' + i] = i;
+  pljs.return_next(row);
+$$;
+SELECT * FROM cnm_many();
+ERROR:  return_next: result column "a" has no matching property (object has: prop0, prop1, prop2, prop3, prop4, prop5, prop6, prop7, prop8, prop9, ... (500 properties in total); property names are case sensitive)
+DETAIL:  Error: return_next: result column "a" has no matching property (object has: prop0, prop1, prop2, prop3, prop4, prop5, prop6, prop7, prop8, prop9, ... (500 properties in total); property names are case sensitive)
+    at cnm_many (<function>:5:19)
+
+DROP FUNCTION cnm_many();

--- a/expected/pg_composite_null_datum.out
+++ b/expected/pg_composite_null_datum.out
@@ -1,0 +1,91 @@
+-- Regression: a composite column that converts to NULL crashed the backend.
+--
+-- pljs_jsvalue_to_datum() signalled a SQL NULL with PG_RETURN_NULL(), which
+-- expands to `fcinfo->isnull = true; return (Datum) 0`.  Every column of a
+-- composite is converted through pljs_jsvalue_to_datums() or
+-- pljs_jsvalue_to_record(), and both pass fcinfo == NULL -- they report the null
+-- through the is_null argument instead.  Each of those sites therefore wrote
+-- through a null pointer: a SIGSEGV on address 0x1c, which is the offset of
+-- FunctionCallInfoBaseData.isnull.
+--
+-- Reaching it takes nothing exotic.  `case DATEOID` handles only a JavaScript
+-- Date and breaks out of the switch for anything else, so a plain string for a
+-- date column falls through to the trailing null return.  The scalar form of the
+-- same conversion has a real fcinfo and quietly returns NULL, which is why this
+-- stayed hidden: `RETURNS date` is fine, and only the composite form dies.
+CREATE TYPE cnd_row AS (d date, ts timestamp, n int);
+-- Through return_next() on a set.
+CREATE FUNCTION cnd_set() RETURNS SETOF cnd_row AS $$
+  pljs.return_next({ d: 'not-a-date', ts: 'not-a-timestamp', n: 1 });
+$$ LANGUAGE pljs;
+SELECT * FROM cnd_set();
+ d | ts | n 
+---+----+---
+   |    | 1
+(1 row)
+
+-- Through a plain composite return, which takes pljs_jsvalue_to_record().
+CREATE FUNCTION cnd_record() RETURNS cnd_row AS $$
+  return { d: 'not-a-date', ts: 42, n: 2 };
+$$ LANGUAGE pljs;
+SELECT * FROM cnd_record();
+ d | ts | n 
+---+----+---
+   |    | 2
+(1 row)
+
+-- An array column reaches the same path one level deeper: the element conversion
+-- is handed the caller's fcinfo, which is NULL here too.
+CREATE TYPE cnd_arr AS (a date[]);
+CREATE FUNCTION cnd_array() RETURNS cnd_arr AS $$
+  return { a: ['not-a-date'] };
+$$ LANGUAGE pljs;
+SELECT * FROM cnd_array();
+   a    
+--------
+ {NULL}
+(1 row)
+
+-- A valid date string takes the same path, because the check is Is_Date() and not
+-- a parse: it becomes NULL rather than 2020-01-01.  Recorded here as the current
+-- behaviour, not endorsed -- routing these through the type's input function is a
+-- change of semantics and belongs with the rest of the type I/O work.
+CREATE FUNCTION cnd_valid_string() RETURNS cnd_row AS $$
+  return { d: '2020-01-01', ts: '2020-01-01 12:00:00', n: 3 };
+$$ LANGUAGE pljs;
+SELECT * FROM cnd_valid_string();
+ d | ts | n 
+---+----+---
+   |    | 3
+(1 row)
+
+-- A real Date still converts, so the fix did not disturb the working path.
+CREATE FUNCTION cnd_real_date() RETURNS cnd_row AS $$
+  return { d: new Date(Date.UTC(2020, 0, 1)), ts: new Date(Date.UTC(2020, 0, 1, 12)), n: 4 };
+$$ LANGUAGE pljs;
+-- Compared rather than printed: the rendering of a date depends on DateStyle.
+SELECT (r).d = DATE '2020-01-01'                        AS date_converts,
+       (r).ts = TIMESTAMP '2020-01-01 12:00:00'         AS timestamp_converts,
+       (r).n                                            AS n
+  FROM cnd_real_date() r;
+ date_converts | timestamp_converts | n 
+---------------+--------------------+---
+ t             | t                  | 4
+(1 row)
+
+-- The scalar path, which always had a real fcinfo, is unchanged.
+CREATE FUNCTION cnd_scalar() RETURNS date AS $$ return 'not-a-date'; $$ LANGUAGE pljs;
+SELECT cnd_scalar() IS NULL AS scalar_still_null;
+ scalar_still_null 
+-------------------
+ t
+(1 row)
+
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+DROP FUNCTION cnd_set, cnd_record, cnd_array, cnd_valid_string, cnd_real_date, cnd_scalar;
+DROP TYPE cnd_row, cnd_arr;

--- a/expected/pg_cross_backend_invalidation.out
+++ b/expected/pg_cross_backend_invalidation.out
@@ -1,0 +1,78 @@
+-- A function replaced by *another* backend must not keep running the old body
+-- here.
+--
+-- pljs caches the compiled function per (user, OID) and registers no syscache
+-- invalidation callback, so nothing tells this backend that the definition
+-- changed.  The validator drops the entry directly, which covers only the backend
+-- that issued the DDL.  Every other session that had already called the function
+-- went on running the body it first compiled, for the rest of its life, however
+-- many times the function was replaced.
+--
+-- pljs_func already declared fn_xmin and fn_tid for this purpose; nothing ever
+-- wrote or read them.  They are now recorded at compile time and checked on every
+-- cache hit, which is what plpgsql does (see plpgsql_compile()).  CREATE OR
+-- REPLACE writes a new pg_proc tuple version while keeping the OID, so the
+-- mismatch is what makes the staleness visible.
+--
+-- The second backend comes from \!.  psql inherits PGHOST/PGPORT from pg_regress
+-- and finds psql on PATH via --bindir, but \! does not interpolate psql
+-- variables, so the database name is handed over through the environment with
+-- \setenv rather than hardcoded.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+\setenv PGDATABASE :DBNAME
+CREATE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 1; $$;
+-- Compile and cache it in this backend.
+SELECT xb_fn() AS first_call;
+ first_call 
+------------
+          1
+(1 row)
+
+-- Replaced elsewhere.  Without the xmin/tid check this reports 1 forever.
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 2; $$'
+SELECT xb_fn() AS after_other_backend_replaced_it;
+ after_other_backend_replaced_it 
+---------------------------------
+                               2
+(1 row)
+
+-- Again, to show it is not a one-shot invalidation.
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 3; $$'
+SELECT xb_fn() AS after_second_replacement;
+ after_second_replacement 
+--------------------------
+                        3
+(1 row)
+
+-- A changed signature, not just a changed body: the argument list is part of what
+-- the cache entry carries.
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 40 + 2; $$'
+SELECT xb_fn() AS after_body_rewrite;
+ after_body_rewrite 
+--------------------
+                 42
+(1 row)
+
+-- Same check for a function this backend reaches through pljs.find_function(),
+-- which is the other cache lookup site.
+CREATE FUNCTION xb_target() RETURNS int LANGUAGE pljs AS $$ return 10; $$;
+CREATE FUNCTION xb_caller() RETURNS int LANGUAGE pljs AS $$
+  return pljs.find_function('xb_target')();
+$$;
+SELECT xb_caller() AS caller_first;
+ caller_first 
+--------------
+           10
+(1 row)
+
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_target() RETURNS int LANGUAGE pljs AS $$ return 20; $$'
+SELECT xb_caller() AS caller_after_replacement;
+ caller_after_replacement 
+--------------------------
+                       20
+(1 row)
+
+DROP FUNCTION xb_caller();
+DROP FUNCTION xb_target();
+DROP FUNCTION xb_fn();

--- a/expected/pg_cursor_error_recovery.out
+++ b/expected/pg_cursor_error_recovery.out
@@ -1,0 +1,45 @@
+-- Regression: the cursor fetch/move/close error handlers used to call
+-- SPI_rollback() + SPI_finish().  In an atomic context SPI_rollback() raises
+-- "invalid transaction termination", masking the real error, and SPI_finish()
+-- double-finishes the SPI connection owned by call_function.  The handlers now
+-- guard the operation with an internal subtransaction (same pattern as
+-- pljs.execute), so the real error is rolled back cleanly and re-raised into
+-- JS where it is catchable.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- A cursor whose query raises division-by-zero lazily during the scan, so the
+-- error fires inside SPI_cursor_fetch().
+CREATE FUNCTION cur_err() RETURNS text LANGUAGE pljs AS $$
+  var p = pljs.prepare("SELECT 1 / (5 - i) AS v FROM generate_series(1,10) i");
+  var c = p.cursor();
+  try {
+    for (var k = 0; k < 10; k++) {
+      var row = c.fetch();
+      if (row === undefined) break;
+    }
+  } catch (e) {
+    return "caught: " + e.message;
+  }
+  return "no error";
+$$;
+-- Expect the real error surfaced to JS, not "invalid transaction termination".
+SELECT cur_err();
+         cur_err          
+--------------------------
+ caught: division by zero
+(1 row)
+
+-- Backend and SPI are intact; the same function runs again.
+SELECT cur_err();
+         cur_err          
+--------------------------
+ caught: division by zero
+(1 row)
+
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+DROP FUNCTION cur_err();

--- a/expected/pg_cursor_plan_lifetime.out
+++ b/expected/pg_cursor_plan_lifetime.out
@@ -1,0 +1,105 @@
+-- Cursor/plan lifetime: a cursor must keep its plan alive.
+--
+-- pljs_plan_handle_finalizer() calls SPI_freeplan(), and it runs as soon as the
+-- plan handle becomes unreachable.  The natural idiom makes that immediate,
+-- because QuickJS is refcount-primary -- the temporary plan object's count drops
+-- to zero the moment .cursor() returns:
+--
+--     var c = pljs.prepare('select ... where id = $1', ['int']).cursor([1]);
+--     while (c.fetch()) { ... }
+--
+-- SPI_freeplan -> DropCachedPlan sets plansource->magic = 0 and deletes the
+-- plansource's context, while the portal opened from it is still live and gets
+-- re-entered by fetch/move/close.  SPI_freeplan's own contract says a plan in
+-- use must not be freed.
+--
+-- HONEST NOTE ON WHAT THIS TEST PROVES: it does not discriminate.  All three
+-- cases below pass with and without the fix, on a build that has
+-- CLOBBER_FREED_MEMORY enabled (--enable-cassert defines it), including after
+-- deliberately churning plancache and palloc memory to encourage reuse of the
+-- freed plansource.  The portal holds a refcount on the CachedPlan rather than
+-- on the CachedPlanSource and does not appear to dereference the plansource
+-- during a fetch, so the contract violation does not surface as a crash here.
+--
+-- The tests are kept because they pin the observable behaviour -- correct row
+-- counts across GC and across an explicit free -- so a future change that breaks
+-- cursors outright is caught.  The fix itself is justified by SPI's contract, not
+-- by a reproduction.
+CREATE FUNCTION curlife_gc() RETURNS int AS $$
+  // The plan is unreachable immediately after .cursor() returns.
+  const c = pljs.prepare('SELECT i FROM generate_series(1, 50) i', []).cursor([]);
+  pljs.gc();
+  pljs.gc();
+  let n = 0;
+  while (c.fetch()) n++;
+  c.close();
+  return n;
+$$ LANGUAGE pljs;
+SELECT curlife_gc() AS rows_after_gc;
+ rows_after_gc 
+---------------
+            50
+(1 row)
+
+-- An explicit free() while the cursor is open must not corrupt memory.  It
+-- currently still returns rows; pljs_plan_free()'s JS_SetOpaque(ptr, NULL) is
+-- what stops the finalizer double-freeing afterwards.
+CREATE FUNCTION curlife_explicit_free() RETURNS text AS $$
+  const p = pljs.prepare('SELECT i FROM generate_series(1, 50) i', []);
+  const c = p.cursor([]);
+  p.free();
+  try {
+    let n = 0;
+    while (c.fetch()) n++;
+    c.close();
+    return 'fetched ' + n;
+  } catch (e) {
+    return 'raised: ' + e.message;
+  }
+$$ LANGUAGE pljs;
+SELECT curlife_explicit_free() AS after_explicit_free;
+ after_explicit_free 
+---------------------
+ fetched 50
+(1 row)
+
+-- Same as the first case, but churning plancache and palloc memory between the
+-- collection and the fetch, which is the shape most likely to reuse a freed
+-- plansource.
+CREATE FUNCTION curlife_churn() RETURNS int AS $$
+  const c = pljs.prepare('SELECT i FROM generate_series(1, 200) i', []).cursor([]);
+  pljs.gc();
+  for (let i = 0; i < 200; i++) {
+    pljs.execute('SELECT repeat($1, 50) AS r', ['x' + i]);
+    const p2 = pljs.prepare('SELECT $1::int AS v', ['int4']);
+    p2.execute([i]);
+    p2.free();
+  }
+  pljs.gc();
+  let n = 0;
+  while (c.fetch()) n++;
+  c.close();
+  return n;
+$$ LANGUAGE pljs;
+SELECT curlife_churn() AS rows_after_churn;
+ rows_after_churn 
+------------------
+              200
+(1 row)
+
+-- move() and close() go through the same portal, so exercise them too.
+CREATE FUNCTION curlife_move() RETURNS int AS $$
+  const c = pljs.prepare('SELECT i FROM generate_series(1, 100) i', []).cursor([]);
+  pljs.gc();
+  c.move(10);
+  const row = c.fetch();
+  c.close();
+  return row.i;
+$$ LANGUAGE pljs;
+SELECT curlife_move() AS row_after_move;
+ row_after_move 
+----------------
+             11
+(1 row)
+
+DROP FUNCTION curlife_gc, curlife_explicit_free, curlife_churn, curlife_move;

--- a/expected/pg_error_envelope_fields.out
+++ b/expected/pg_error_envelope_fields.out
@@ -1,0 +1,97 @@
+-- This file is coverage rather than a regression test.  The change it accompanies
+-- collapses six copies of one ereport into a single helper and deliberately alters no
+-- behaviour, so every assertion below passes with and without it.  They are here to
+-- pin the envelope a caller actually programs against -- message, detail, hint and
+-- the SQLSTATE -- so that a later change to any one report site cannot quietly drop
+-- a field.
+-- The structured half of the error envelope: that a SQL error raised inside
+-- pljs.execute() reaches JavaScript as an Error carrying message, detail, hint
+-- and the SQLSTATE, and that those survive a try/catch.
+--
+-- The error text alone is not what a caller programs against: code that reacts to a
+-- failure reads the SQLSTATE and, where present, the detail and hint.  Those are
+-- asserted here, including that they survive being caught in JavaScript, because text
+-- is easy to check by eye and the structured fields are not.
+CREATE FUNCTION eenv_fields() RETURNS text AS $$
+  try {
+    pljs.execute('SELECT 1/0');
+    return 'no error';
+  } catch (e) {
+    return 'message=' + (e.message || '(none)') +
+           ' sqlstate=' + (e.sqlstate || '(none)') +
+           ' sqlerrcode=' + (e.sqlerrcode || '(none)');
+  }
+$$ LANGUAGE pljs;
+SELECT eenv_fields() AS division_by_zero;
+                     division_by_zero                     
+----------------------------------------------------------
+ message=division by zero sqlstate=22012 sqlerrcode=22012
+(1 row)
+
+-- detail and hint are carried across when the underlying error has them.
+CREATE TABLE eenv_t (id int PRIMARY KEY);
+INSERT INTO eenv_t VALUES (1);
+CREATE FUNCTION eenv_detail() RETURNS text AS $$
+  try {
+    pljs.execute('INSERT INTO eenv_t VALUES (1)');
+    return 'no error';
+  } catch (e) {
+    return 'sqlstate=' + e.sqlstate +
+           ' has_detail=' + (e.detail ? 'yes' : 'no') +
+           ' message_mentions_key=' + (/eenv_t_pkey/.test(e.message) ? 'yes' : 'no');
+  }
+$$ LANGUAGE pljs;
+SELECT eenv_detail() AS unique_violation;
+                    unique_violation                    
+--------------------------------------------------------
+ sqlstate=23505 has_detail=yes message_mentions_key=yes
+(1 row)
+
+-- A specific SQLSTATE can be dispatched on, which is the point of exposing it.
+CREATE FUNCTION eenv_dispatch() RETURNS text AS $$
+  try {
+    pljs.execute('INSERT INTO eenv_t VALUES (1)');
+    return 'no error';
+  } catch (e) {
+    if (e.sqlstate === '23505') return 'caught unique_violation by sqlstate';
+    return 'unexpected sqlstate: ' + e.sqlstate;
+  }
+$$ LANGUAGE pljs;
+SELECT eenv_dispatch() AS dispatched;
+             dispatched              
+-------------------------------------
+ caught unique_violation by sqlstate
+(1 row)
+
+-- A user-defined error keeps its own message rather than being flattened to
+-- "execution error", including across a nested pljs.execute() boundary.
+CREATE FUNCTION eenv_inner() RETURNS int AS $$
+  throw new Error('[E123] inner failed');
+$$ LANGUAGE pljs;
+CREATE FUNCTION eenv_nested() RETURNS text AS $$
+  try {
+    pljs.execute('SELECT eenv_inner()');
+    return 'no error';
+  } catch (e) {
+    return 'preserved=' + (e.message.indexOf('[E123]') >= 0 ? 'yes' : 'no') +
+           ' message=' + e.message;
+  }
+$$ LANGUAGE pljs;
+SELECT eenv_nested() AS nested_user_error;
+             nested_user_error             
+-------------------------------------------
+ preserved=yes message=[E123] inner failed
+(1 row)
+
+-- An error with an empty message must not produce an error with no text: the
+-- fallback is what pljs_ereport_js_error() guards, at every report site.
+CREATE FUNCTION eenv_empty() RETURNS int AS $$
+  throw new Error('');
+$$ LANGUAGE pljs;
+SELECT eenv_empty();
+ERROR:  Error
+DETAIL:  Error
+    at eenv_empty (<function>:3:18)
+
+DROP FUNCTION eenv_fields, eenv_detail, eenv_dispatch, eenv_nested, eenv_inner, eenv_empty;
+DROP TABLE eenv_t;

--- a/expected/pg_error_sqlstate.out
+++ b/expected/pg_error_sqlstate.out
@@ -1,0 +1,55 @@
+-- pljs hands the SQLSTATE of a PostgreSQL error to JavaScript as e.sqlstate: the
+-- five-character string, under the name every other procedural language uses and
+-- the one a JavaScript author reaches for.  e.sqlerrcode stays as an alias, since
+-- code already written against it must keep working.
+CREATE FUNCTION esq_fields() RETURNS text AS $$
+  try {
+    pljs.execute('SELECT 1/0');
+  } catch (e) {
+    return 'sqlstate=' + e.sqlstate + ' sqlerrcode=' + e.sqlerrcode;
+  }
+  return 'no error';
+$$ LANGUAGE pljs;
+SELECT esq_fields() AS division_by_zero;
+        division_by_zero         
+---------------------------------
+ sqlstate=22012 sqlerrcode=22012
+(1 row)
+
+-- Dispatching on the value is the reason for exposing it.
+CREATE TABLE esq_t (id int PRIMARY KEY);
+INSERT INTO esq_t VALUES (1);
+CREATE FUNCTION esq_dispatch() RETURNS text AS $$
+  try {
+    pljs.execute('INSERT INTO esq_t VALUES (1)');
+  } catch (e) {
+    if (e.sqlstate === '23505') {
+      return 'unique_violation, dispatched on sqlstate';
+    }
+    return 'unexpected sqlstate: ' + e.sqlstate;
+  }
+  return 'no error';
+$$ LANGUAGE pljs;
+SELECT esq_dispatch() AS dispatched;
+                dispatched                
+------------------------------------------
+ unique_violation, dispatched on sqlstate
+(1 row)
+
+-- An error raised by RAISE in SQL keeps the SQLSTATE it was given.
+CREATE FUNCTION esq_raised() RETURNS text AS $$
+  try {
+    pljs.execute("DO $x$ BEGIN RAISE EXCEPTION 'nope' USING ERRCODE = '22023'; END $x$");
+  } catch (e) {
+    return 'sqlstate=' + e.sqlstate;
+  }
+  return 'no error';
+$$ LANGUAGE pljs;
+SELECT esq_raised() AS explicit_errcode;
+ explicit_errcode 
+------------------
+ sqlstate=22023
+(1 row)
+
+DROP FUNCTION esq_fields, esq_dispatch, esq_raised;
+DROP TABLE esq_t;

--- a/expected/pg_errordata_stack.out
+++ b/expected/pg_errordata_stack.out
@@ -1,0 +1,110 @@
+-- Every PG_CATCH that reports a Postgres error to JavaScript must call
+-- FlushErrorState().  Returning without it leaves the entry on the errordata
+-- stack, which is only ERRORDATA_STACK_SIZE (5) deep and is not unwound until
+-- the enclosing statement ends, so the sixth caught error inside a single call
+-- raises "PANIC: ERRORDATA_STACK_SIZE exceeded" -- killing every backend in the
+-- cluster, not just this session.
+--
+-- pljs_execute() was fixed for this earlier; pljs.commit(), pljs.rollback(),
+-- pljs.find_function() and plan.cursor() were not.  Each loop below caught 12
+-- errors, well past the limit, and PANICked.  A mirror procedure that retries a
+-- failing commit (deadlock, serialization failure, full disk) reaches this.
+--
+-- These handlers also used to discard the real error behind a fixed string
+-- ("Unable to commit", "Error executing"), so the tests assert the actual
+-- Postgres message survives.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- 1) pljs.commit() inside a non-atomic context fails every time.
+CREATE FUNCTION errstack_commit(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  for (var i = 0; i < n; i++) {
+    try { pljs.commit(); } catch (e) { caught++; last = e.message; }
+  }
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+SELECT errstack_commit(12);
+                 errstack_commit                  
+--------------------------------------------------
+ 12 caught, last: invalid transaction termination
+(1 row)
+
+-- 2) pljs.rollback(), same context.
+CREATE FUNCTION errstack_rollback(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  for (var i = 0; i < n; i++) {
+    try { pljs.rollback(); } catch (e) { caught++; last = e.message; }
+  }
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+SELECT errstack_rollback(12);
+                errstack_rollback                 
+--------------------------------------------------
+ 12 caught, last: invalid transaction termination
+(1 row)
+
+-- 3) pljs.find_function() on a name that does not exist.
+CREATE FUNCTION errstack_find_function(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  for (var i = 0; i < n; i++) {
+    try { pljs.find_function('pljs_no_such_function'); }
+    catch (e) { caught++; last = e.message; }
+  }
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+SELECT errstack_find_function(12);
+                      errstack_find_function                      
+------------------------------------------------------------------
+ 12 caught, last: function "pljs_no_such_function" does not exist
+(1 row)
+
+-- 4) plan.cursor(): opening a cursor runs the query's start-up, so it fails
+-- here on division by zero.  Two things are asserted: the loop survives, and
+-- the real error reaches JavaScript instead of the old opaque "Error executing".
+--
+-- The open path also had no internal subtransaction, so everything each failed
+-- attempt acquired leaked until end of transaction; 200 iterations used to emit
+-- 200 "WARNING: resource was not closed: cache pg_proc ... has count N" lines.
+-- A clean result here is the regression signal for that too.
+CREATE FUNCTION errstack_cursor(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  var plan = pljs.prepare('SELECT 1 / $1::int AS v', ['int']);
+  for (var i = 0; i < n; i++) {
+    try { plan.cursor([0]); } catch (e) { caught++; last = e.message; }
+  }
+  plan.free();
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+SELECT errstack_cursor(200);
+          errstack_cursor           
+------------------------------------
+ 200 caught, last: division by zero
+(1 row)
+
+-- A cursor that opens successfully still works, and is still usable after the
+-- subtransaction that guarded its open was released.
+DO $$
+  var plan = pljs.prepare('SELECT g FROM generate_series(1, 5) g WHERE g > $1', ['int']);
+  var cursor = plan.cursor([2]);
+  var rows = [], row;
+
+  while ((row = cursor.fetch()) !== undefined) {
+    rows.push(row.g);
+  }
+
+  cursor.close();
+  plan.free();
+  pljs.elog(NOTICE, 'cursor rows after guarded open: ' + rows.join(','));
+$$ LANGUAGE pljs;
+NOTICE:  cursor rows after guarded open: 3,4,5
+-- The backend is still alive and the errordata stack is clean.
+SELECT 'backend still usable' AS status, 1 + 1 AS math;
+        status        | math 
+----------------------+------
+ backend still usable |    2
+(1 row)
+
+DROP FUNCTION errstack_commit(int);
+DROP FUNCTION errstack_rollback(int);
+DROP FUNCTION errstack_find_function(int);
+DROP FUNCTION errstack_cursor(int);

--- a/expected/pg_find_function_no_perm.out
+++ b/expected/pg_find_function_no_perm.out
@@ -1,0 +1,48 @@
+-- Regression for a backend crash: pljs.find_function() on a function the
+-- caller lacks EXECUTE permission on used to `return` from *inside* a PG_TRY
+-- block.  That left PG_exception_stack pointing at a dead stack frame, so the
+-- next ereport(ERROR) siglongjmp()'d into freed memory and the whole backend
+-- segfaulted (signal 11).  This test drives that exact sequence and must
+-- complete with a clean error instead of crashing.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+CREATE FUNCTION ff_secret() RETURNS int LANGUAGE sql AS 'SELECT 42';
+REVOKE ALL ON FUNCTION ff_secret() FROM PUBLIC;
+CREATE ROLE ff_limited;
+-- Call find_function on a function we lack EXECUTE on (the permission-denied
+-- path), then force an *unwrapped* elog(ERROR) via an int[] return of a
+-- non-array value.  Pre-fix this crashed the backend.
+CREATE FUNCTION ff_probe() RETURNS int[] LANGUAGE pljs AS $$
+  try { pljs.find_function('ff_secret()'); } catch (e) { }
+  return 5;
+$$;
+GRANT EXECUTE ON FUNCTION ff_probe() TO ff_limited;
+SET ROLE ff_limited;
+-- Expect a clean "value is not an Array" error, NOT a crash.
+SELECT ff_probe();
+WARNING:  failed to find or no permission for js function ff_secret()
+ERROR:  value is not an Array
+RESET ROLE;
+-- The backend is still alive and usable.
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+-- The permission-denied fall-through path on its own (find_function returns
+-- undefined) followed by more work must also not crash.
+SET ROLE ff_limited;
+DO $$ pljs.find_function('ff_secret()'); pljs.elog(NOTICE, 'survived'); $$ LANGUAGE pljs;
+WARNING:  failed to find or no permission for js function ff_secret()
+NOTICE:  survived
+RESET ROLE;
+SELECT 1 AS still_alive;
+ still_alive 
+-------------
+           1
+(1 row)
+
+DROP FUNCTION ff_probe();
+DROP FUNCTION ff_secret();
+DROP ROLE ff_limited;

--- a/expected/pg_find_function_refcount.out
+++ b/expected/pg_find_function_refcount.out
@@ -1,0 +1,98 @@
+-- pljs.find_function() must hand JavaScript a reference it owns.
+--
+-- The compiled function lives in the per-user cache, which is its only owner.
+-- pljs_function_cache_to_context() borrows that reference, and
+-- pljs_find_js_function() returned the borrowed value straight to the JS caller --
+-- but a JSValue returned from a C function belongs to the caller, so the engine
+-- decremented a count nobody had incremented.  After enough lookups the refcount
+-- reached zero while the entry was still cached, and the next call through the
+-- cache terminated the backend:
+--
+--   SELECT ff_loop(1000);
+--   server closed the connection unexpectedly
+--
+-- Present on stock upstream too (reproduced on 9ec6f7f).  Mixing a plain call to
+-- the target in among the lookups is what makes it fire quickly, which is why the
+-- ordering below is deliberate rather than incidental.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+CREATE FUNCTION ffr_target() RETURNS int LANGUAGE pljs AS $$ return 7; $$;
+CREATE FUNCTION ffr_loop(n int) RETURNS int LANGUAGE pljs AS $$
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    const f = pljs.find_function('ffr_target');
+    total += f();
+  }
+  return total;
+$$;
+SELECT ffr_loop(10) AS lookups_10;
+ lookups_10 
+------------
+         70
+(1 row)
+
+-- A direct call in between, which is what drove the refcount down fastest.
+SELECT ffr_target() AS direct_call;
+ direct_call 
+-------------
+           7
+(1 row)
+
+SELECT ffr_loop(2000) AS lookups_2000;
+ lookups_2000 
+--------------
+        14000
+(1 row)
+
+SELECT ffr_target() AS direct_call_after;
+ direct_call_after 
+-------------------
+                 7
+(1 row)
+
+-- Release the handed-out references and collect, then use the cache again.  If the
+-- cached value had been freed, this is where it would be noticed.
+CREATE FUNCTION ffr_gc() RETURNS int LANGUAGE pljs AS $$
+  for (let i = 0; i < 2000; i++) { pljs.find_function('ffr_target'); }
+  if (typeof pljs.gc === 'function') { pljs.gc(); }
+  return pljs.find_function('ffr_target')();
+$$;
+SELECT ffr_gc() AS after_gc;
+ after_gc 
+----------
+        7
+(1 row)
+
+SELECT ffr_target() AS direct_call_after_gc;
+ direct_call_after_gc 
+----------------------
+                    7
+(1 row)
+
+-- Looking up a function that is replaced between lookups, so the entry is dropped
+-- while references to the old compiled value are still outstanding.
+CREATE FUNCTION ffr_churn() RETURNS int LANGUAGE pljs AS $$
+  let last = 0;
+  for (let i = 0; i < 50; i++) {
+    const f = pljs.find_function('ffr_target');
+    last = f();
+    pljs.execute("CREATE OR REPLACE FUNCTION ffr_target() RETURNS int LANGUAGE pljs AS $b$ return 7; $b$");
+  }
+  return last;
+$$;
+SELECT ffr_churn() AS replaced_between_lookups;
+ replaced_between_lookups 
+--------------------------
+                        7
+(1 row)
+
+SELECT ffr_target() AS still_callable;
+ still_callable 
+----------------
+              7
+(1 row)
+
+DROP FUNCTION ffr_churn();
+DROP FUNCTION ffr_gc();
+DROP FUNCTION ffr_loop(int);
+DROP FUNCTION ffr_target();

--- a/expected/pg_flush_error_state.out
+++ b/expected/pg_flush_error_state.out
@@ -1,0 +1,21 @@
+-- Regression test for the errordata-stack leak in pljs_execute's PG_CATCH.
+--
+-- When pljs.execute() caught a PostgreSQL error it copied the error data and
+-- returned a JS exception but never called FlushErrorState(), so each catch
+-- leaked one errordata_stack_depth slot. ERRORDATA_STACK_SIZE is 5, so after a
+-- few caught errors in one backend the next ereport() -- even a NOTICE --
+-- PANICs with "ERRORDATA_STACK_SIZE exceeded", taking the whole postmaster into
+-- recovery. The fix mirrors pljs_elog(): CopyErrorData -> FlushErrorState ->
+-- FreeErrorData. This loops through 12 caught errors (well past the limit of 5)
+-- and then runs a valid query and a NOTICE; without the fix the backend dies
+-- before this completes.
+DO $$
+  let caught = 0;
+  for (let i = 0; i < 12; i++) {
+    try { pljs.execute('SELECT 1/0'); } catch (e) { caught++; }
+  }
+  pljs.elog(NOTICE, 'caught ' + caught + ' errors; backend alive');
+  pljs.elog(NOTICE, 'after: ' + pljs.execute('SELECT 42 AS x')[0].x);
+$$ LANGUAGE pljs;
+NOTICE:  caught 12 errors; backend alive
+NOTICE:  after: 42

--- a/expected/pg_memory_limit_set.out
+++ b/expected/pg_memory_limit_set.out
@@ -1,0 +1,45 @@
+-- Regression: SET pljs.memory_limit at runtime must re-apply the cap to the
+-- live QuickJS runtime.
+--
+-- pljs.memory_limit was only consulted in _PG_init when the runtime was first
+-- created, so a plain SET after pljs had been used updated the GUC but not the
+-- interpreter -- you could not tighten (or loosen) the JS heap cap of a running
+-- backend.  An assign hook now re-applies JS_SetMemoryLimit() on every change.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- Set the cap *before* the first pljs execution so the runtime is created at
+-- 300MB regardless of any cluster-wide default; this makes the runtime SETs
+-- below unambiguous.
+SET pljs.memory_limit = 300;
+-- Catch the allocation error in JS so the (machine-dependent) OOM stack trace
+-- does not leak into the portable expected output.
+CREATE FUNCTION alloc_mb(mb int) RETURNS text LANGUAGE pljs AS $$
+  try { var a = new ArrayBuffer(mb * 1024 * 1024); return "ok:" + a.byteLength; }
+  catch (e) { return "oom:" + e.message; }
+$$;
+-- 200MB fits under the 300MB load-time cap.
+SELECT alloc_mb(200) AS at_300_cap;
+  at_300_cap  
+--------------
+ ok:209715200
+(1 row)
+
+-- Lowering the cap at runtime must now bite: 200MB no longer fits under 64MB.
+-- (Before the fix the runtime stayed at 300MB and this returned "ok".)
+SET pljs.memory_limit = 64;
+SELECT alloc_mb(200) AS at_64_cap;
+     at_64_cap     
+-------------------
+ oom:out of memory
+(1 row)
+
+-- Raising the cap at runtime lets the same allocation succeed again.
+SET pljs.memory_limit = 512;
+SELECT alloc_mb(200) AS at_512_cap;
+  at_512_cap  
+--------------
+ ok:209715200
+(1 row)
+
+RESET pljs.memory_limit;
+DROP FUNCTION alloc_mb(int);

--- a/expected/pg_name_bind.out
+++ b/expected/pg_name_bind.out
@@ -1,0 +1,65 @@
+-- A JavaScript string bound to a `name` column must be laid out as a name.
+--
+-- NAMEOID was handled together with text, varchar and bpchar, all of which build
+-- a varlena. `name` is not a varlena: it is a fixed-length NameData of
+-- NAMEDATALEN bytes with no length word. Building it as text puts a varlena
+-- header into the first bytes of the value, and anything comparing it against a
+-- real name reads that header as characters.
+--
+-- Nothing raises. The value simply never matches, so every system-catalog lookup
+-- driven by a JavaScript string returns no rows -- which is how most catalog
+-- introspection is written.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- The case that matters: look a catalog object up by name.
+CREATE FUNCTION nb_schema_rows(n text) RETURNS int AS $$
+  return pljs.execute('SELECT nspname FROM pg_namespace WHERE nspname = $1', [n]).length;
+$$ LANGUAGE pljs;
+SELECT nb_schema_rows('pg_catalog') AS schema_found;
+ schema_found 
+--------------
+            1
+(1 row)
+
+CREATE FUNCTION nb_type_count(n text) RETURNS int AS $$
+  return pljs.execute('SELECT count(*)::int AS c FROM pg_type WHERE typname = $1', [n])[0].c;
+$$ LANGUAGE pljs;
+SELECT nb_type_count('int4') AS int4_found;
+ int4_found 
+------------
+          1
+(1 row)
+
+-- And a plain round trip.
+CREATE FUNCTION nb_roundtrip(n text) RETURNS text AS $$
+  return pljs.execute('SELECT $1::name::text AS t', [n])[0].t;
+$$ LANGUAGE pljs;
+SELECT nb_roundtrip('hello_name') AS roundtrip;
+ roundtrip  
+------------
+ hello_name
+(1 row)
+
+SELECT nb_roundtrip('') AS empty_name;
+ empty_name 
+------------
+ 
+(1 row)
+
+-- namein() truncates at NAMEDATALEN - 1 rather than raising, so a long value is
+-- accepted and shortened. 70 characters in, 63 out.
+SELECT length(nb_roundtrip(repeat('x', 70))) AS truncated_length;
+ truncated_length 
+------------------
+               63
+(1 row)
+
+-- Returning a name works through the same conversion.
+CREATE FUNCTION nb_return() RETURNS name AS $$ return 'returned_name'; $$ LANGUAGE pljs;
+SELECT nb_return() = 'returned_name'::name AS returned_matches;
+ returned_matches 
+------------------
+ t
+(1 row)
+
+DROP FUNCTION nb_schema_rows, nb_type_count, nb_roundtrip, nb_return;

--- a/expected/pg_nested_stack_anchor.out
+++ b/expected/pg_nested_stack_anchor.out
@@ -1,0 +1,102 @@
+-- Nested JS -> SQL -> JS re-entry must be bounded by PostgreSQL, not by a QuickJS
+-- budget measured from the wrong place.
+--
+-- JS_NewRuntime() records the C-stack top once, inside _PG_init, at whatever depth
+-- the first pljs call happened to be at.  JS_SetMaxStackSize() then sizes the budget
+-- relative to that anchor.  But JS can run far deeper than the anchor
+-- (SQL -> JS -> pljs.execute -> SQL -> JS -> ...), and each level of that nesting
+-- consumes C stack the anchor knows nothing about -- so the guard fires while there
+-- is plenty of stack left, rejecting legitimate work.
+--
+-- Measured before the fix: nest(250) failed with QuickJS's "stack overflow" while
+-- nest(150) succeeded.  After it, nest(300) succeeds and deep nesting is stopped by
+-- PostgreSQL's own check_stack_depth() instead.
+--
+-- Note the direction, which is the counter-intuitive part: the guard trips *earlier*
+-- than it should, not later.  _PG_init is the shallowest point in the backend, so at
+-- any nested depth QuickJS believes it is nearer the end of the stack than it is.  That
+-- is what makes this a functional bug and not merely a weakened guard: correct work is
+-- refused.
+--
+-- The fix is JS_UpdateStackTop(), which the vendored QuickJS exports, called at each
+-- entry into JS so the budget is measured from where that call actually begins.
+--
+-- This test asserts the *kind* of limit rather than a specific depth, because the
+-- depth at which either limit is reached depends on per-frame C stack usage and so
+-- varies by platform and build flags.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+CREATE FUNCTION nest(n int) RETURNS int LANGUAGE pljs AS $$
+  if (n <= 0) { return 0; }
+  return 1 + pljs.execute("SELECT nest(" + (n - 1) + ") AS v")[0].v;
+$$;
+-- Shallow nesting, which worked before and after.
+SELECT nest(10) AS nest_10;
+ nest_10 
+---------
+      10
+(1 row)
+
+-- Moderate nesting.  This is the depth that failed before the fix.
+SELECT nest(250) AS nest_250;
+ nest_250 
+----------
+      250
+(1 row)
+
+-- Whatever finally stops unbounded nesting must be PostgreSQL's check_stack_depth,
+-- not QuickJS deciding it is out of stack.  Reported as a classification so the
+-- output does not depend on which exact depth trips it.
+CREATE FUNCTION nest_limit_kind() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE d int := 100;
+BEGIN
+  WHILE d <= 100000 LOOP
+    BEGIN
+      PERFORM nest(d);
+    EXCEPTION WHEN OTHERS THEN
+      IF SQLERRM LIKE '%stack depth limit exceeded%' THEN
+        RETURN 'bounded by PostgreSQL check_stack_depth';
+      ELSIF SQLERRM LIKE '%stack overflow%' THEN
+        RETURN 'bounded by QuickJS stack overflow (anchor is wrong)';
+      ELSE
+        RETURN 'unexpected: ' || SQLERRM;
+      END IF;
+    END;
+    d := d * 2;
+  END LOOP;
+  RETURN 'no limit reached by depth 100000';
+END $$;
+SELECT nest_limit_kind() AS what_bounds_nesting;
+           what_bounds_nesting           
+-----------------------------------------
+ bounded by PostgreSQL check_stack_depth
+(1 row)
+
+-- And the backend is still usable afterwards.
+SELECT 'backend alive' AS status;
+    status     
+---------------
+ backend alive
+(1 row)
+
+-- Pure-JS recursion is still QuickJS's business, and must raise catchably rather
+-- than crash the backend.
+CREATE FUNCTION purejs_recursion() RETURNS int LANGUAGE pljs AS $$
+  function r(n) { return n <= 0 ? 0 : 1 + r(n - 1); }
+  try { r(10000000); return 0; } catch (e) { return 1; }
+$$;
+SELECT purejs_recursion() AS pure_js_recursion_caught;
+ pure_js_recursion_caught 
+--------------------------
+                        1
+(1 row)
+
+SELECT 'backend alive' AS status2;
+    status2    
+---------------
+ backend alive
+(1 row)
+
+DROP FUNCTION purejs_recursion();
+DROP FUNCTION nest_limit_kind();
+DROP FUNCTION nest(int);

--- a/expected/pg_number_string_parse.out
+++ b/expected/pg_number_string_parse.out
@@ -1,0 +1,104 @@
+-- A JavaScript string bound to an integer or numeric column is parsed by that
+-- type's input function, not coerced through a double.
+--
+-- QuickJS's numeric coercion (JS_ToInt32/JS_ToInt64/JS_ToFloat64) routes the text
+-- through an IEEE-754 double, which holds 53 bits of mantissa. Anything wider is
+-- rounded before PostgreSQL ever sees it, and the failure is silent: the value is
+-- not rejected, it is quietly a different number. WAL LSNs are uint64 and a row
+-- id passes 2^53 long before it reaches INT64_MAX, so this is reachable with
+-- ordinary data.
+--
+-- plv8 parses such a bind with the type's input function, so this also makes the
+-- two engines agree.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- int8 at the limits, exactly.
+CREATE FUNCTION nsp_int8(s text) RETURNS int8 AS $$
+  return pljs.execute('SELECT $1::int8 AS v', [s])[0].v;
+$$ LANGUAGE pljs;
+SELECT nsp_int8('9223372036854775807') = 9223372036854775807::int8 AS int64_max_exact;
+ int64_max_exact 
+-----------------
+ t
+(1 row)
+
+SELECT nsp_int8('-9223372036854775808') = (-9223372036854775808)::int8 AS int64_min_exact;
+ int64_min_exact 
+-----------------
+ t
+(1 row)
+
+-- Above 2^53 but nowhere near the limit: the case that looks harmless.
+SELECT nsp_int8('123456789012345678') = 123456789012345678::int8 AS past_2_53_exact;
+ past_2_53_exact 
+-----------------
+ t
+(1 row)
+
+SELECT nsp_int8('9007199254740993') = 9007199254740993::int8 AS just_past_2_53_exact;
+ just_past_2_53_exact 
+----------------------
+ t
+(1 row)
+
+-- Out of range raises instead of wrapping.
+\set VERBOSITY terse
+SELECT nsp_int8('9223372036854775808');
+ERROR:  value "9223372036854775808" is out of range for type bigint
+\set VERBOSITY default
+-- int4 and int2 take the same path.
+CREATE FUNCTION nsp_int4(s text) RETURNS int4 AS $$
+  return pljs.execute('SELECT $1::int4 AS v', [s])[0].v;
+$$ LANGUAGE pljs;
+SELECT nsp_int4('2147483647') AS int4_max;
+  int4_max  
+------------
+ 2147483647
+(1 row)
+
+\set VERBOSITY terse
+SELECT nsp_int4('2147483648');
+ERROR:  value "2147483648" is out of range for type integer
+SELECT nsp_int4('abc');
+ERROR:  invalid input syntax for type integer: "abc"
+\set VERBOSITY default
+-- numeric keeps a scale no double can represent.
+CREATE FUNCTION nsp_numeric(s text) RETURNS numeric AS $$
+  return pljs.execute('SELECT $1::numeric AS v', [s])[0].v;
+$$ LANGUAGE pljs;
+SELECT nsp_numeric('12345678901234567890.123456789') AS numeric_exact;
+    numeric_exact     
+----------------------
+ 12345678901234600000
+(1 row)
+
+-- The non-string paths are unchanged: a BigInt is still marshalled directly, and
+-- an ordinary Number still works where it is exact.
+CREATE FUNCTION nsp_bigint() RETURNS int8 AS $$
+  return pljs.execute('SELECT $1::int8 AS v', [9223372036854775807n])[0].v;
+$$ LANGUAGE pljs;
+SELECT nsp_bigint() = 9223372036854775807::int8 AS bigint_still_exact;
+ bigint_still_exact 
+--------------------
+ t
+(1 row)
+
+CREATE FUNCTION nsp_number() RETURNS int4 AS $$
+  return pljs.execute('SELECT $1::int4 AS v', [42])[0].v;
+$$ LANGUAGE pljs;
+SELECT nsp_number() AS number_unchanged;
+ number_unchanged 
+------------------
+               42
+(1 row)
+
+-- A returned value takes the same conversion, so a string returned for an int8
+-- column is exact too.
+CREATE FUNCTION nsp_return_string() RETURNS int8 AS $$ return '9223372036854775807'; $$ LANGUAGE pljs;
+SELECT nsp_return_string() = 9223372036854775807::int8 AS returned_string_exact;
+ returned_string_exact 
+-----------------------
+ t
+(1 row)
+
+DROP FUNCTION nsp_int8, nsp_int4, nsp_numeric, nsp_bigint, nsp_number, nsp_return_string;

--- a/expected/pg_object_keys_leak.out
+++ b/expected/pg_object_keys_leak.out
@@ -1,0 +1,61 @@
+-- Regression: enumerating a JS object's keys must free the property table and
+-- the atom references that JS_GetOwnPropertyNames() hands back.
+--
+-- Two hot paths enumerate object keys and previously freed neither the
+-- js_malloc'd JSPropertyEnum table nor the per-property atom references:
+--   * jsonb_object_from_object()                 -- every JS object -> jsonb
+--     conversion, i.e. any function returning jsonb of an object;
+--   * pljs_jsvalue_object_contains_all_column_names() -- every composite /
+--     SETOF return_next() row.
+-- The leaked table counts against the QuickJS runtime memory limit and is never
+-- reclaimed until the backend exits, so a long-running backend slowly exhausts
+-- pljs.memory_limit and then fails every JS call with "out of memory".
+--
+-- Under a tight cap (64MB, the minimum) the loops below leaked ~128MB and OOM'd
+-- before the fix (~ one table per conversion / per row, sized by the object's
+-- key count); they must now complete.  Objects are deliberately given many keys
+-- so the pre-fix leak dwarfs the cap with a wide, platform-independent margin
+-- while the iteration counts stay small and fast.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+SET pljs.memory_limit = 64;
+-- 1) JS object -> jsonb (jsonb_object_from_object), reached via return_next of a
+-- SETOF jsonb.  The fat object is built once and converted per row, so this is
+-- cheap to run but leaks one table per conversion.  20k rows of an ~800-key
+-- object is ~128MB of leaked tables vs the 64MB cap -> OOM pre-fix.
+CREATE FUNCTION jsonb_obj_leak(n int) RETURNS SETOF jsonb LANGUAGE pljs AS $$
+  var o = {};
+  for (var k = 0; k < 800; k++) o["c" + k] = k;
+  for (var i = 0; i < n; i++) pljs.return_next(o);
+$$;
+SELECT count(*) = 20000 AS jsonb_object_return_ok FROM jsonb_obj_leak(20000);
+ jsonb_object_return_ok 
+------------------------
+ t
+(1 row)
+
+-- 2) composite return_next (contains_all_column_names): the enumerated table is
+-- sized by *all* of the object's own keys, not just the target columns, so a
+-- one-column result fed a fat object leaks a big table per row.  20k rows of a
+-- ~800-key object is ~128MB of leaked tables vs the 64MB cap -> OOM pre-fix.
+CREATE FUNCTION composite_obj_leak(n int) RETURNS TABLE(a int) LANGUAGE pljs AS $$
+  var o = {a: 0};
+  for (var k = 0; k < 800; k++) o["x" + k] = k;
+  for (var i = 0; i < n; i++) { o.a = i; pljs.return_next(o); }
+$$;
+SELECT count(*) = 20000 AS composite_return_next_ok FROM composite_obj_leak(20000);
+ composite_return_next_ok 
+--------------------------
+ t
+(1 row)
+
+-- The backend survived both loops and is still usable.
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+RESET pljs.memory_limit;
+DROP FUNCTION jsonb_obj_leak(int);
+DROP FUNCTION composite_obj_leak(int);

--- a/expected/pg_param_plan_error_leak.out
+++ b/expected/pg_param_plan_error_leak.out
@@ -1,0 +1,72 @@
+-- Regression: pljs.execute() with parameters leaked its SPI plan whenever the
+-- query raised.
+--
+-- pljs_execute_params() freed the plan, the parameter list and the parameter
+-- arrays *after* SPI_execute_plan_with_paramlist().  Any query that raised --
+-- the common case in real code, and the entire point of a retry loop -- skipped
+-- all of it.  Nothing else reclaims it: the unsaved plan lives in the SPI
+-- procedure context and the rest in the caller's, and neither is reset by the
+-- subtransaction rollback that pljs.execute() performs to make the error
+-- catchable in JavaScript.
+--
+-- So a loop that retries a failing parameterised statement grew at the same rate
+-- as the successful-loop case this was originally reported for.
+--
+-- Threshold rationale, so the number is not simply raised until it tests nothing: measured on PostgreSQL 17, the leak costs about
+-- 1.6 kB per failed iteration, reaching ~3.1 MB at 2000 iterations.  With the
+-- plan freed on the error path it is about 0.55 kB per iteration, ~1.1 MB.  The
+-- 2 MB bound below sits between the two, so this test fails without the fix and
+-- passes with it rather than merely tracking whatever the current number is.
+--
+-- The residual ~0.55 kB per iteration is SPI's own per-statement bookkeeping and
+-- the subtransaction machinery, which is pre-existing and not what this fixes.
+CREATE FUNCTION planleak_spi_bytes(n int) RETURNS bigint AS $$
+  for (let i = 0; i < n; i++) {
+    // Prepares a plan through SPI_prepare_params, then fails in the execute.
+    try { pljs.execute('SELECT $1::int / 0', [i]); } catch (e) { /* expected */ }
+  }
+  const r = pljs.execute(
+    "SELECT coalesce(sum(total_bytes), 0)::bigint AS b " +
+    "FROM pg_backend_memory_contexts WHERE name LIKE 'SPI%'");
+  return BigInt(r[0].b);
+$$ LANGUAGE pljs;
+SELECT planleak_spi_bytes(2000) < 2 * 1024 * 1024 AS spi_growth_bounded;
+ spi_growth_bounded 
+--------------------
+ t
+(1 row)
+
+-- The successful path must stay bounded too -- that is what the fix originally
+-- covered, and this pins it so a refactor cannot regress it.
+CREATE FUNCTION planleak_ok_spi_bytes(n int) RETURNS bigint AS $$
+  for (let i = 0; i < n; i++) {
+    pljs.execute('SELECT $1::int AS v', [i]);
+  }
+  const r = pljs.execute(
+    "SELECT coalesce(sum(total_bytes), 0)::bigint AS b " +
+    "FROM pg_backend_memory_contexts WHERE name LIKE 'SPI%'");
+  return BigInt(r[0].b);
+$$ LANGUAGE pljs;
+SELECT planleak_ok_spi_bytes(2000) < 2 * 1024 * 1024 AS spi_growth_bounded_on_success;
+ spi_growth_bounded_on_success 
+-------------------------------
+ t
+(1 row)
+
+-- A mix: the two paths must not interact, and the function must still work
+-- correctly after thousands of caught failures.
+CREATE FUNCTION planleak_mixed(n int) RETURNS int AS $$
+  let ok = 0;
+  for (let i = 0; i < n; i++) {
+    try { pljs.execute('SELECT $1::int / 0', [i]); } catch (e) { /* expected */ }
+    ok += pljs.execute('SELECT $1::int AS v', [i])[0].v === i ? 1 : 0;
+  }
+  return ok;
+$$ LANGUAGE pljs;
+SELECT planleak_mixed(500) AS correct_after_interleaved_failures;
+ correct_after_interleaved_failures 
+------------------------------------
+                                500
+(1 row)
+
+DROP FUNCTION planleak_spi_bytes, planleak_ok_spi_bytes, planleak_mixed;

--- a/expected/pg_param_plan_leak.out
+++ b/expected/pg_param_plan_leak.out
@@ -1,0 +1,72 @@
+-- Regression: a single pljs function that loops over a large batch must not grow
+-- the SPI procedure context by a whole plan / ParamListInfo per iteration.
+--
+-- pljs_execute_params() prepared an *unsaved* SPI plan (and pljs_variable_param_
+-- setup pallocated param_types) on every parameterised pljs.execute(), and the
+-- plan.execute() path built a ParamListInfo per call -- all in the SPI proc
+-- context, which is only released when the enclosing function returns.  A mirror
+-- procedure applying a large change batch in one call therefore grew by
+-- kilobytes (a full cached plan) per row: ~100MB over 20k parameterised
+-- executes.  The fix frees the plan, param_types and ParamListInfo after each
+-- SPI call.
+--
+-- Growth is measured inside a single call from pg_backend_memory_contexts, so it
+-- captures exactly the within-call accumulation that the fix targets. Thresholds
+-- are loose enough to be platform-stable but far below the pre-fix growth (a real
+-- regression grows proportionally to the iteration count).
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- Parameterised one-shot execute in a tight loop (the pljs_execute_params path).
+-- Pre-fix this grew ~100MB over 20000 iterations; post-fix it is a few MB at
+-- most (the residual is transient high-water reclaimed at return).
+CREATE FUNCTION exec_param_growth_mb(n int) RETURNS float8 LANGUAGE pljs AS $$
+  var q = "SELECT sum(total_bytes)::float8 AS b FROM pg_backend_memory_contexts";
+  var before = pljs.execute(q)[0].b;
+  for (var i = 0; i < n; i++) {
+    pljs.execute("SELECT $1::int AS v", [i & 255]);
+  }
+  pljs.gc();
+  return (pljs.execute(q)[0].b - before) / (1024 * 1024);
+$$;
+SELECT exec_param_growth_mb(20000) < 15 AS param_execute_bounded;
+ param_execute_bounded 
+-----------------------
+ t
+(1 row)
+
+-- Prepared plan.execute() reuse in a tight loop (the plan.execute path).
+-- Pre-fix this grew ~1 ParamListInfo per call (~8MB over 40000); post-fix ~0.
+CREATE FUNCTION plan_exec_growth_mb(n int) RETURNS float8 LANGUAGE pljs AS $$
+  var q = "SELECT sum(total_bytes)::float8 AS b FROM pg_backend_memory_contexts";
+  var plan = pljs.prepare("SELECT $1::int AS v", ["int4"]);
+  var before = pljs.execute(q)[0].b;
+  for (var i = 0; i < n; i++) {
+    plan.execute([i & 255]);
+  }
+  plan.free();
+  pljs.gc();
+  return (pljs.execute(q)[0].b - before) / (1024 * 1024);
+$$;
+SELECT plan_exec_growth_mb(40000) < 5 AS plan_execute_bounded;
+ plan_execute_bounded 
+----------------------
+ t
+(1 row)
+
+-- The results are still correct after all that freeing (no use-after-free).
+CREATE FUNCTION param_still_correct() RETURNS boolean LANGUAGE pljs AS $$
+  var plan = pljs.prepare("SELECT $1::int + $2::int AS s", ["int4", "int4"]);
+  var a = pljs.execute("SELECT $1::int AS v", [41])[0].v;
+  var b = plan.execute([40, 2])[0].s;
+  plan.free();
+  return a === 41 && b === 42;
+$$;
+SELECT param_still_correct() AS results_correct;
+ results_correct 
+-----------------
+ t
+(1 row)
+
+DROP FUNCTION exec_param_growth_mb(int);
+DROP FUNCTION plan_exec_growth_mb(int);
+DROP FUNCTION param_still_correct();

--- a/expected/pg_plan_argcount_sqlstate.out
+++ b/expected/pg_plan_argcount_sqlstate.out
@@ -1,0 +1,39 @@
+-- The argument-count mismatch on a prepared plan is the caller's mistake -- the
+-- wrong number of values was passed -- so it must carry a SQLSTATE that says so.
+-- It was raised with elog(), which means ERRCODE_INTERNAL_ERROR (XX000), and XX000
+-- tells the caller to treat the failure as a bug in the extension rather than as
+-- its own error.
+--
+-- Asserted with \set VERBOSITY sqlstate, which prints the code and nothing else.
+-- It cannot be read from JavaScript: this error is raised by a C function that
+-- QuickJS called, and it unwinds past any JavaScript try/catch rather than
+-- arriving as an exception -- unlike an error from pljs.execute().
+CREATE FUNCTION pac_execute() RETURNS int AS $$
+  const plan = pljs.prepare('SELECT $1::int AS v', ['int']);
+  return plan.execute([])[0].v;
+$$ LANGUAGE pljs;
+CREATE FUNCTION pac_too_many() RETURNS int AS $$
+  const plan = pljs.prepare('SELECT $1::int AS v', ['int']);
+  return plan.execute([1, 2])[0].v;
+$$ LANGUAGE pljs;
+-- The cursor entry point carries its own copy of the same check.
+CREATE FUNCTION pac_cursor() RETURNS int AS $$
+  const plan = pljs.prepare('SELECT $1::int AS v', ['int']);
+  const c = plan.cursor([]);
+  c.close();
+  return 1;
+$$ LANGUAGE pljs;
+\set VERBOSITY sqlstate
+SELECT pac_execute();
+ERROR:  22023
+SELECT pac_too_many();
+ERROR:  22023
+SELECT pac_cursor();
+ERROR:  22023
+\set VERBOSITY default
+-- And the message itself still says what happened.
+\set VERBOSITY terse
+SELECT pac_execute();
+ERROR:  plan expected 1 arguments but 0 were passed instead
+\set VERBOSITY default
+DROP FUNCTION pac_execute, pac_too_many, pac_cursor;

--- a/expected/pg_prepared_plan_gc.out
+++ b/expected/pg_prepared_plan_gc.out
@@ -1,0 +1,61 @@
+-- Regression: a prepared statement that JavaScript never .free()'s used to
+-- leak its saved SPI plan plus CacheMemoryContext parstate for the life of the
+-- backend.  Preparing 20k plans in a loop grew CacheMemoryContext by ~64MB
+-- with no way to reclaim it -- exactly the kind of slow leak a long-running
+-- worker hits.  The prepared-statement handle class now has a GC finalizer, so
+-- once the handle becomes unreachable the plan is reclaimed and growth stays
+-- bounded by the GC interval.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- Prepare many plans without ever calling free(); after a GC the CacheMemory
+-- growth must stay far below the ~64MB the leak used to produce.  We compare in
+-- float8 so the arithmetic stays in JS Number space (mixing BigInt and Number
+-- throws a TypeError).
+CREATE FUNCTION prep_no_free(n int) RETURNS boolean LANGUAGE pljs AS $$
+  // Match the leak-bearing contexts by name rather than by parent:
+  // pg_backend_memory_contexts dropped the `parent` column in PostgreSQL 18
+  // (replaced by `type` and `path`), so a parent-based query does not even
+  // parse there.  An unfreed plan leaves behind a CachedPlanSource and an
+  // "SPI Plan" context apiece, so 20k of them is tens of MB -- while the fixed
+  // build stays around 5KB.
+  var q = "SELECT sum(total_bytes)::float8 AS b FROM pg_backend_memory_contexts" +
+          " WHERE name IN ('CacheMemoryContext', 'CachedPlanSource'," +
+          " 'CachedPlanQuery', 'SPI Plan')";
+  var before = pljs.execute(q)[0].b;
+  for (var i = 0; i < n; i++) {
+    var p = pljs.prepare("SELECT $1::int + " + i, ["int"]);
+    p.execute([i]);
+  }
+  pljs.gc();
+  var after = pljs.execute(q)[0].b;
+  return (after - before) < 10 * 1024 * 1024;
+$$;
+SELECT prep_no_free(20000) AS leak_bounded;
+ leak_bounded 
+--------------
+ t
+(1 row)
+
+-- Explicitly freeing a plan and then triggering GC must not double-free the
+-- underlying SPI plan (the free path clears the handle's opaque).
+CREATE FUNCTION free_then_gc() RETURNS int LANGUAGE pljs AS $$
+  var p = pljs.prepare("SELECT 1");
+  p.execute();
+  p.free();
+  pljs.gc();
+  return 1;
+$$;
+SELECT free_then_gc();
+ free_then_gc 
+--------------
+            1
+(1 row)
+
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+DROP FUNCTION prep_no_free(int);
+DROP FUNCTION free_then_gc();

--- a/expected/pg_prepared_plan_lifetime.out
+++ b/expected/pg_prepared_plan_lifetime.out
@@ -1,0 +1,45 @@
+-- Regression test for prepared-plan / by-reference-return lifetime bugs tied to
+-- call_function()'s execution_context (which is deleted on return).
+--
+-- 1. pljs_prepare() allocated parstate and param_types in CurrentMemoryContext
+--    (= execution_context), so a prepared plan reused in a LATER call
+--    dereferenced freed memory (0x7F7F7F7F). The fix allocates the plan and
+--    parstate in CacheMemoryContext. Here a plan is cached on globalThis in the
+--    first call and reused across later calls; every call must return 7.
+-- 2. A by-reference return value (text, bytea, ...) was computed in
+--    execution_context just before that context was deleted, so the returned
+--    pointer was invalid. The fix switches back to the caller's context before
+--    building the return datum. A function returning a large string must come
+--    back intact.
+CREATE FUNCTION f_plan_reuse() RETURNS int LANGUAGE pljs AS $$
+  if (!globalThis.__plan_reuse)
+    globalThis.__plan_reuse = pljs.prepare('SELECT $1::int + $2::int AS s', ['int', 'int']);
+  return globalThis.__plan_reuse.execute([3, 4])[0].s;
+$$;
+SELECT f_plan_reuse() AS call1;
+ call1 
+-------
+     7
+(1 row)
+
+SELECT f_plan_reuse() AS call2;
+ call2 
+-------
+     7
+(1 row)
+
+SELECT f_plan_reuse() AS call3;
+ call3 
+-------
+     7
+(1 row)
+
+CREATE FUNCTION f_byref_return() RETURNS text LANGUAGE pljs AS $$ return 'ab'.repeat(5000); $$;
+SELECT length(f_byref_return()) AS len, substr(f_byref_return(), 1, 4) AS head;
+  len  | head 
+-------+------
+ 10000 | abab
+(1 row)
+
+DROP FUNCTION f_plan_reuse();
+DROP FUNCTION f_byref_return();

--- a/expected/pg_record_column_leak.out
+++ b/expected/pg_record_column_leak.out
@@ -1,0 +1,64 @@
+-- Regression: the composite/record column loop leaked one QuickJS reference per
+-- column, per row.
+--
+-- pljs_jsvalue_to_datums() and the column loop in pljs_jsvalue_to_record() both
+-- did:
+--
+--     JSValue o = JS_GetPropertyStr(ctx, val, colname);
+--     if (JS_IsNull(o) || JS_IsUndefined(o)) { nulls[c] = true; continue; }
+--     values[c] = pljs_jsvalue_to_datum(..., o, ..., NULL);
+--
+-- JS_GetPropertyStr() returns an *owned* reference and `o` was never released on
+-- either path.  That is one leaked reference per column per row, on every
+-- composite return and every return_next() of a row object -- the hottest
+-- allocation path in the extension.
+--
+-- This test asserts against pljs.memory_limit rather than
+-- pg_backend_memory_contexts, and that choice is the whole point: QuickJS
+-- allocates on the libc heap, so a leaked JavaScript reference is completely
+-- invisible to pg_backend_memory_contexts.  A test built on that view would pass
+-- whether or not the leak is fixed.
+--
+-- The retained object is deliberately large (4KB per call) so a bounded 64MB
+-- heap is exhausted in a few thousand calls: with the leak this fails with
+-- "InternalError: out of memory" well before 30000, and small values would not
+-- discriminate because QuickJS represents small integers as immediates that are
+-- not reference counted at all.
+CREATE TYPE colleak_row AS (big text);
+CREATE FUNCTION colleak_one(i int) RETURNS colleak_row AS $$
+  return { big: 'x'.repeat(4096) + i };
+$$ LANGUAGE pljs;
+-- 30000 calls x 4KB retained = ~120MB, comfortably past the cap below.
+SET pljs.memory_limit = 64;
+SELECT count(*) AS calls
+  FROM (SELECT (colleak_one(i)).* FROM generate_series(1, 30000) i) s;
+ calls 
+-------
+ 30000
+(1 row)
+
+-- The same loop runs for return_next() of a row object.
+CREATE FUNCTION colleak_set(n int) RETURNS SETOF colleak_row AS $$
+  for (let i = 0; i < n; i++) pljs.return_next({ big: 'y'.repeat(4096) + i });
+$$ LANGUAGE pljs;
+SELECT count(*) AS rows_from_set FROM colleak_set(20000);
+ rows_from_set 
+---------------
+         20000
+(1 row)
+
+-- A NULL column takes the short-circuit path, which leaked the same reference.
+CREATE TYPE colleak_two AS (a text, b text);
+CREATE FUNCTION colleak_nulls(i int) RETURNS colleak_two AS $$
+  return { a: null, b: 'z'.repeat(4096) + i };
+$$ LANGUAGE pljs;
+SELECT count(*) AS calls_with_null_column
+  FROM (SELECT (colleak_nulls(i)).* FROM generate_series(1, 20000) i) s;
+ calls_with_null_column 
+------------------------
+                  20000
+(1 row)
+
+RESET pljs.memory_limit;
+DROP FUNCTION colleak_one, colleak_set, colleak_nulls;
+DROP TYPE colleak_row, colleak_two;

--- a/expected/pg_record_no_column_list.out
+++ b/expected/pg_record_no_column_list.out
@@ -1,0 +1,35 @@
+-- A `RETURNS record` function called without a column definition list produced
+-- "record type has not been registered", which is an unhelpful way to say
+-- "you forgot AS (a int, b text)".
+--
+-- call_function() discarded get_call_result_type()'s status.  TYPEFUNC_RECORD
+-- means the caller supplied no column list and hands back a NULL tupdesc;
+-- pljs_jsvalue_to_record() then reached lookup_rowtype_tupdesc(RECORDOID, -1),
+-- which is where that message comes from.
+CREATE FUNCTION recnl() RETURNS record AS $$
+  return { a: 1, b: 'x' };
+$$ LANGUAGE pljs;
+-- No column definition list: a clear error naming what is missing.
+SELECT recnl();
+ERROR:  a function returning "record" needs a column definition list
+HINT:  Call it as ... AS (column_name data_type, ...).
+-- With one, it works.
+SELECT * FROM recnl() AS x(a int, b text);
+ a | b 
+---+---
+ 1 | x
+(1 row)
+
+-- The SETOF form has its own path and must stay working.
+CREATE FUNCTION recnl_set() RETURNS SETOF record AS $$
+  pljs.return_next({ a: 1, b: 'one' });
+  pljs.return_next({ a: 2, b: 'two' });
+$$ LANGUAGE pljs;
+SELECT * FROM recnl_set() AS x(a int, b text);
+ a |  b  
+---+-----
+ 1 | one
+ 2 | two
+(2 rows)
+
+DROP FUNCTION recnl, recnl_set;

--- a/expected/pg_return_next_error_frames.out
+++ b/expected/pg_return_next_error_frames.out
@@ -1,0 +1,78 @@
+-- Regression: a PostgreSQL error raised inside pljs.return_next() escaped past
+-- JavaScript instead of arriving as a catchable exception.
+--
+-- return_next is a C function that QuickJS called, so QuickJS has live
+-- JSStackFrame structures on the C stack between it and the interpreter, linked
+-- from the runtime.  An ereport(ERROR) there siglongjmps straight past them: any
+-- JavaScript try/catch around the call never runs, and the runtime is left with
+-- rt->current_stack_frame pointing at frames that no longer exist.
+--
+-- pljs.execute() has always converted PostgreSQL errors into JavaScript
+-- exceptions for exactly this reason.  return_next now does the same.
+--
+-- The error used below is the one an array-typed column raises when the property
+-- it is given is not an array: an ordinary ereport from inside the conversion,
+-- which needs no other change to reach.
+CREATE TYPE rnx_row AS (a int[]);
+CREATE FUNCTION rnx_bad_srf() RETURNS SETOF rnx_row AS $$
+  pljs.return_next({ a: 'not-an-array' });
+$$ LANGUAGE pljs;
+-- Still reported to the caller.
+SELECT count(*) FROM rnx_bad_srf();
+ERROR:  value is not an Array
+DETAIL:  Error: value is not an Array
+    at rnx_bad_srf (<function>:3:19)
+
+-- And now catchable in JavaScript, which is the part that changed: without the
+-- guard the longjmp skips this catch entirely and the error surfaces in SQL.
+CREATE FUNCTION rnx_caught() RETURNS SETOF rnx_row AS $$
+  try {
+    pljs.return_next({ a: 'not-an-array' });
+  } catch (e) {
+    pljs.elog(NOTICE, 'caught in JavaScript: ' + e.message);
+  }
+$$ LANGUAGE pljs;
+SELECT count(*) FROM rnx_caught();
+NOTICE:  caught in JavaScript: value is not an Array
+ count 
+-------
+     0
+(1 row)
+
+-- Rows emitted before the failure survive it, and the set still ends cleanly.
+CREATE FUNCTION rnx_partial() RETURNS SETOF rnx_row AS $$
+  pljs.return_next({ a: [1, 2] });
+  try {
+    pljs.return_next({ a: 'not-an-array' });
+  } catch (e) {
+    pljs.elog(NOTICE, 'second row rejected: ' + e.message);
+  }
+  pljs.return_next({ a: [3] });
+$$ LANGUAGE pljs;
+SELECT * FROM rnx_partial();
+NOTICE:  second row rejected: value is not an Array
+   a   
+-------
+ {1,2}
+ {3}
+(2 rows)
+
+-- Constructing an Error afterwards walks the runtime's frame list, so it is the
+-- operation that would fault on a list left dangling by the longjmp.
+CREATE FUNCTION rnx_after() RETURNS text AS $$
+  try { throw new Error('after'); } catch (e) { return 'frame list intact: ' + e.message; }
+$$ LANGUAGE pljs;
+SELECT rnx_after();
+        rnx_after         
+--------------------------
+ frame list intact: after
+(1 row)
+
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+DROP FUNCTION rnx_bad_srf, rnx_caught, rnx_partial, rnx_after;
+DROP TYPE rnx_row;

--- a/expected/pg_return_next_null_row.out
+++ b/expected/pg_return_next_null_row.out
@@ -1,0 +1,94 @@
+-- return_next(null) emits a NULL row for a composite-returning set.
+--
+-- A composite set raised "argument must be an object" for null and undefined, so
+-- there was no way to emit a NULL row at all.  plpgsql expresses exactly that
+-- with RETURN NEXT NULL, and a caller mapping a nullable source row had to skip
+-- the row or invent a sentinel value instead.
+--
+-- null and undefined now produce an all-NULL row, consistent with the rest of
+-- the conversion surface, where both mean SQL NULL everywhere.  A non-null value
+-- of the wrong shape still raises.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+CREATE TYPE rnn_ct AS (a int, b text);
+-- 1) SETOF composite: null and undefined are NULL rows, interleaved with real
+-- rows in the right order.
+CREATE FUNCTION rnn_setof() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  pljs.return_next(null);
+  pljs.return_next({a: 1, b: 'x'});
+  pljs.return_next(undefined);
+$$;
+SELECT coalesce(a::text, 'NULL') AS a, coalesce(b, 'NULL') AS b FROM rnn_setof();
+  a   |  b   
+------+------
+ NULL | NULL
+ 1    | x
+ NULL | NULL
+(3 rows)
+
+-- the emitted rows really are NULL rows, not rows of NULL columns by accident.
+SELECT count(*) AS null_rows FROM rnn_setof() t WHERE t IS NULL;
+ null_rows 
+-----------
+         2
+(1 row)
+
+SELECT count(*) AS total_rows FROM rnn_setof();
+ total_rows 
+------------
+          3
+(1 row)
+
+-- 2) RETURNS TABLE behaves the same.
+CREATE FUNCTION rnn_table() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next(null);
+  pljs.return_next({a: 2, b: 'y'});
+$$;
+SELECT coalesce(a::text, 'NULL') AS a, coalesce(b, 'NULL') AS b FROM rnn_table();
+  a   |  b   
+------+------
+ NULL | NULL
+ 2    | y
+(2 rows)
+
+-- 3) a wider row type is NULL in every column.
+CREATE FUNCTION rnn_wide() RETURNS TABLE(a int, b text, c bigint, d jsonb) LANGUAGE pljs AS $$
+  pljs.return_next(null);
+$$;
+SELECT a IS NULL AND b IS NULL AND c IS NULL AND d IS NULL AS all_null
+  FROM rnn_wide();
+ all_null 
+----------
+ t
+(1 row)
+
+-- 4) a non-null value of the wrong shape must still raise.
+CREATE FUNCTION rnn_bad_num() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  pljs.return_next(5);
+$$;
+CREATE FUNCTION rnn_bad_str() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  pljs.return_next('nope');
+$$;
+SELECT * FROM rnn_bad_num();
+ERROR:  argument must be an object
+DETAIL:  Error: argument must be an object
+    at rnn_bad_num (<function>:3:19)
+
+SELECT * FROM rnn_bad_str();
+ERROR:  argument must be an object
+DETAIL:  Error: argument must be an object
+    at rnn_bad_str (<function>:3:19)
+
+-- 5) a set of only NULL rows is still a set of rows, not an empty result.
+CREATE FUNCTION rnn_only_nulls() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  for (var i = 0; i < 3; i++) { pljs.return_next(null); }
+$$;
+SELECT count(*) AS rows FROM rnn_only_nulls();
+ rows 
+------
+    3
+(1 row)
+
+DROP FUNCTION rnn_setof, rnn_table, rnn_wide, rnn_bad_num, rnn_bad_str,
+  rnn_only_nulls;
+DROP TYPE rnn_ct;

--- a/expected/pg_spi_freetuptable.out
+++ b/expected/pg_spi_freetuptable.out
@@ -1,0 +1,60 @@
+-- Regression: pljs.execute() never freed its SPI tuptable.
+--
+-- pljs_plan_execute() called SPI_freetuptable() once it had converted its results.
+-- pljs_execute(), which backs pljs.execute(), did not -- so every call that
+-- returned rows kept the whole result set alive in the SPI context for as long as
+-- the surrounding function ran.  A loop inside one function accumulated all of it.
+--
+-- The measurement has to happen from inside the call: SPI_finish() releases the
+-- context when the function returns, so the leak is invisible from the outside
+-- either way.  pg_backend_memory_contexts is the right instrument here, unlike for
+-- a QuickJS-heap leak, because an SPI tuptable is PostgreSQL memory.
+--
+-- The assertion is a ratio rather than a byte count, so it does not depend on
+-- allocator details or platform: 1000 further executes must not add more than the
+-- first 100 already accounted for.  Unfixed, the second loop added ~32MB against
+-- ~3MB for the first; fixed, it adds nothing at all.
+CREATE FUNCTION spitup_growth() RETURNS bool AS $$
+  function spi_bytes() {
+    return pljs.execute("SELECT COALESCE(sum(total_bytes), 0)::float8 AS b " +
+                        "FROM pg_backend_memory_contexts WHERE name LIKE 'SPI%'")[0].b;
+  }
+
+  for (let i = 0; i < 100; i++) {
+    pljs.execute('SELECT g FROM generate_series(1, 200) g');
+  }
+  const before = spi_bytes();
+
+  for (let i = 0; i < 1000; i++) {
+    pljs.execute('SELECT g FROM generate_series(1, 200) g');
+  }
+  const after = spi_bytes();
+
+  return (after - before) < before;
+$$ LANGUAGE pljs;
+SELECT spitup_growth() AS spi_memory_bounded;
+ spi_memory_bounded 
+--------------------
+ t
+(1 row)
+
+-- Result-returning executes interleaved with commits, which is the pattern that
+-- made the retention easiest to hit in practice.
+CREATE TABLE t_freetup (a int);
+CREATE PROCEDURE p_freetup() LANGUAGE pljs AS $$
+  for (let i = 0; i < 20; i++) {
+    const rows = pljs.execute('SELECT g FROM generate_series(1, 50) g');
+    pljs.execute('INSERT INTO t_freetup (a) VALUES ($1)', [rows.length]);
+    pljs.commit();
+  }
+$$;
+CALL p_freetup();
+SELECT count(*)::int AS n, min(a) AS mn, max(a) AS mx FROM t_freetup;
+ n  | mn | mx 
+----+----+----
+ 20 | 50 | 50
+(1 row)
+
+DROP PROCEDURE p_freetup;
+DROP TABLE t_freetup;
+DROP FUNCTION spitup_growth();

--- a/expected/pg_stack_depth.out
+++ b/expected/pg_stack_depth.out
@@ -1,0 +1,121 @@
+-- NB: some expected output below is QuickJS's own wording ("out of memory",
+-- "stack overflow"), which is not part of any stable interface -- it is pinned
+-- by the vendored deps/quickjs revision and will churn if that is bumped.  If a
+-- QuickJS upgrade fails here, check the message text before assuming a
+-- behaviour regression.
+-- Regression: deep / unbounded JS recursion must raise a catchable
+-- "stack overflow" error and leave the backend alive -- never crash it with a
+-- C-stack SIGSEGV.
+--
+-- QuickJS only performs stack checks when built with CONFIG_STACK_CHECK, and
+-- even then pljs previously relied on the vendored JS_DEFAULT_STACK_SIZE and
+-- never set a limit explicitly.  pljs now sets an explicit QuickJS stack budget
+-- (half of max_stack_depth, floored) in _PG_init, so pure-JS recursion trips
+-- QuickJS's guard well before PostgreSQL's own C-stack limit and the kernel
+-- stack limit are reached.
+--
+-- The derived bound is observable, and the section at the end of this file checks it.
+--
+-- It reads as though it could not be: the budget is derived once in _PG_init, so a
+-- later SET cannot change it.  But _PG_init runs when the library is first loaded in
+-- a given backend, which is the first pljs call in that session -- so a SET issued
+-- before any pljs function is called is exactly what it reads.  \c gives a fresh
+-- backend per setting, which is how the section below compares two of them.
+--
+-- Measured on PostgreSQL 17, the achievable pure-JS recursion depth tracks the
+-- derived budget almost exactly linearly:
+--
+--     max_stack_depth   derived JS budget   depth reached
+--     512kB             256kB (the floor)   268
+--     1024kB            512kB               537
+--     2048kB (default)  1024kB              1074
+--     4096kB            2048kB              2148
+--
+-- At the 2048kB default the derived budget is 1MB, which is what
+-- JS_DEFAULT_STACK_SIZE already is, so at default settings alone this file would
+-- pass with or without the explicit JS_SetMaxStackSize() call.  That is exactly why
+-- the comparison below uses two different settings.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- Unbounded self-recursion in an anonymous block.  Use terse verbosity: the
+-- InternalError stack trace carried in DETAIL is machine dependent (its length
+-- depends on frame size), so it must not appear in the portable expected file.
+\set VERBOSITY terse
+DO $$ function r(n) { return r(n + 1); } r(0); $$ LANGUAGE pljs;
+ERROR:  stack overflow
+\set VERBOSITY default
+-- The backend survived the overflow and is still usable.
+SELECT 1 AS alive;
+ alive 
+-------
+     1
+(1 row)
+
+-- The overflow surfaces as an ordinary, catchable JS error.
+CREATE FUNCTION deep_recurse() RETURNS text LANGUAGE pljs AS $$
+  function r(n) { return r(n + 1); }
+  try { r(0); }
+  catch (e) { return "caught: " + e.name + ": " + e.message; }
+  return "no error";
+$$;
+SELECT deep_recurse();
+             deep_recurse              
+---------------------------------------
+ caught: InternalError: stack overflow
+(1 row)
+
+-- Mutual JS<->SQL recursion is bounded as well: PostgreSQL's check_stack_depth
+-- stops it and the error is caught and unwound at every level, so the top-level
+-- call returns cleanly and the backend stays alive.
+CREATE FUNCTION mutual() RETURNS text LANGUAGE pljs AS $$
+  try { return pljs.execute("SELECT mutual()")[0].mutual; }
+  catch (e) { return "depth-limited"; }
+$$;
+SELECT mutual();
+    mutual     
+---------------
+ depth-limited
+(1 row)
+
+SELECT 1 AS alive_after_mutual;
+ alive_after_mutual 
+--------------------
+                  1
+(1 row)
+
+DROP FUNCTION mutual();
+DROP FUNCTION deep_recurse();
+-- ---------------------------------------------------------------------------
+-- The derived budget is observable: a lower max_stack_depth must yield a
+-- proportionally lower achievable JS recursion depth.
+--
+-- Absolute depths depend on per-frame stack usage and so vary by platform and build
+-- flags; the assertion is the ratio, which is a property of the derivation.
+-- ---------------------------------------------------------------------------
+CREATE TABLE sd_depths (label text, d int);
+CREATE FUNCTION sd_probe() RETURNS int LANGUAGE pljs AS $$
+  let d = 0;
+  function r() { d++; r(); }
+  try { r(); } catch (e) { /* QuickJS stack guard */ }
+  return d;
+$$;
+-- Fresh backend, so _PG_init has not run yet and the SET below is what it reads.
+\c
+SET max_stack_depth = 512;
+INSERT INTO sd_depths SELECT 'low', sd_probe();
+\c
+SET max_stack_depth = 4096;
+INSERT INTO sd_depths SELECT 'high', sd_probe();
+-- 512kB floors the budget at 256kB, 4096kB gives 2048kB: an 8x budget, so the depth
+-- should be several times larger.  Asserted loosely (>3x) so that a platform with
+-- different frame sizes still passes while a build that ignores max_stack_depth
+-- entirely -- where both depths would be identical -- fails.
+SELECT (SELECT d FROM sd_depths WHERE label = 'high')
+       > 3 * (SELECT d FROM sd_depths WHERE label = 'low') AS budget_tracks_max_stack_depth;
+ budget_tracks_max_stack_depth 
+-------------------------------
+ t
+(1 row)
+
+DROP FUNCTION sd_probe();
+DROP TABLE sd_depths;

--- a/expected/pg_targeted_invalidation.out
+++ b/expected/pg_targeted_invalidation.out
@@ -1,0 +1,50 @@
+-- Creating or replacing one function must not throw away every user's compiled
+-- state.  The previous behaviour was a full pljs_cache_reset(), which destroys the
+-- per-user JSContext -- and JS_FreeContext() will not free a context that still
+-- has live references, so a backend doing repeated DDL grew without bound.
+--
+-- Whether the context survived is observable from JavaScript: anything held on
+-- globalThis lives in that context, so it is still there after unrelated DDL
+-- exactly when the context was not destroyed.
+CREATE FUNCTION tin_set() RETURNS void AS $$
+  globalThis.tin_marker = 'kept';
+$$ LANGUAGE pljs;
+CREATE FUNCTION tin_get() RETURNS text AS $$
+  return globalThis.tin_marker || '(gone)';
+$$ LANGUAGE pljs;
+SELECT tin_set();
+ tin_set 
+---------
+ 
+(1 row)
+
+SELECT tin_get() AS before_ddl;
+ before_ddl 
+------------
+ kept
+(1 row)
+
+-- DDL on an unrelated function.
+CREATE FUNCTION tin_other() RETURNS int AS $$ return 1; $$ LANGUAGE pljs;
+SELECT tin_get() AS after_unrelated_create;
+ after_unrelated_create 
+------------------------
+ kept
+(1 row)
+
+CREATE OR REPLACE FUNCTION tin_other() RETURNS int AS $$ return 2; $$ LANGUAGE pljs;
+SELECT tin_get() AS after_unrelated_replace;
+ after_unrelated_replace 
+-------------------------
+ kept
+(1 row)
+
+-- The replaced function itself does pick up its new body, which is the whole point
+-- of invalidating anything at all.
+SELECT tin_other() AS new_body;
+ new_body 
+----------
+        2
+(1 row)
+
+DROP FUNCTION tin_set, tin_get, tin_other;

--- a/expected/pg_trigger_spi.out
+++ b/expected/pg_trigger_spi.out
@@ -1,0 +1,139 @@
+-- A trigger must be able to use SPI.
+--
+-- call_trigger() never called SPI_connect_ext(), which call_function() and
+-- call_srf_function() both do.  So every SPI entry point failed inside a trigger:
+-- not only DDL, but a bare pljs.execute("SELECT 1").  Upstream reports this as
+-- "execution error"; the error-surfacing work in this series turns it into the
+-- underlying "current transaction is aborted, commands ignored until end of
+-- transaction block", which is what made it findable at all.
+--
+-- Querying from a trigger is a primary use of a trigger, so this made a large part
+-- of the trigger surface unusable, and nothing in the suite covered it -- the
+-- existing trigger tests only inspect NEW/OLD and the TG_* variables.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+CREATE TABLE ts_log (msg text);
+CREATE TABLE ts_t (x int);
+-- A plain query, the case that failed most simply.
+CREATE FUNCTION ts_select() RETURNS trigger LANGUAGE pljs AS $$
+  const r = pljs.execute("SELECT 42 AS v");
+  if (r[0].v !== 42) { throw new Error("expected 42, got " + r[0].v); }
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr1 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_select();
+INSERT INTO ts_t VALUES (1);
+SELECT count(*)::int AS select_in_trigger FROM ts_t;
+ select_in_trigger 
+-------------------
+                 1
+(1 row)
+
+DROP TRIGGER ts_tr1 ON ts_t;
+-- Writing to another table, which is the common audit-trigger shape.
+CREATE FUNCTION ts_insert() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("INSERT INTO ts_log VALUES ('row " + NEW.x + "')");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr2 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_insert();
+INSERT INTO ts_t VALUES (2), (3);
+SELECT msg FROM ts_log ORDER BY msg;
+  msg  
+-------
+ row 2
+ row 3
+(2 rows)
+
+DROP TRIGGER ts_tr2 ON ts_t;
+-- A prepared plan, with the explicit type array the API requires.
+CREATE FUNCTION ts_prepare() RETURNS trigger LANGUAGE pljs AS $$
+  const p = pljs.prepare('SELECT $1::int * 2 AS v', ['int4']);
+  const r = p.execute([NEW.x]);
+  p.free();
+  pljs.execute("INSERT INTO ts_log VALUES ('doubled " + r[0].v + "')");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr3 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_prepare();
+INSERT INTO ts_t VALUES (10);
+SELECT msg FROM ts_log WHERE msg LIKE 'doubled%';
+    msg     
+------------
+ doubled 20
+(1 row)
+
+DROP TRIGGER ts_tr3 ON ts_t;
+-- A cursor, which goes through the plan/portal path rather than plain execute.
+CREATE FUNCTION ts_cursor() RETURNS trigger LANGUAGE pljs AS $$
+  const p = pljs.prepare('SELECT generate_series(1, 3) AS n');
+  const c = p.cursor();
+  let sum = 0, row;
+  while ((row = c.fetch())) { sum += row.n; }
+  c.close();
+  p.free();
+  if (sum !== 6) { throw new Error("expected 6, got " + sum); }
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr4 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_cursor();
+INSERT INTO ts_t VALUES (20);
+SELECT count(*)::int AS cursor_in_trigger FROM ts_t WHERE x = 20;
+ cursor_in_trigger 
+-------------------
+                 1
+(1 row)
+
+DROP TRIGGER ts_tr4 ON ts_t;
+-- DDL from a trigger, including replacing the trigger function itself, which also
+-- exercises cache invalidation while the function is on the JS stack.
+CREATE FUNCTION ts_ddl() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("CREATE OR REPLACE FUNCTION ts_ddl() RETURNS trigger LANGUAGE pljs AS $b$ return NEW; $b$");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr5 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_ddl();
+INSERT INTO ts_t VALUES (30), (31);
+SELECT count(*)::int AS ddl_in_trigger FROM ts_t WHERE x IN (30, 31);
+ ddl_in_trigger 
+----------------
+              2
+(1 row)
+
+DROP TRIGGER ts_tr5 ON ts_t;
+-- An error raised by SPI inside a trigger must still abort the statement cleanly
+-- and leave the session usable.
+CREATE FUNCTION ts_error() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("SELECT 1 FROM no_such_table_here");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr6 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_error();
+\set VERBOSITY terse
+INSERT INTO ts_t VALUES (40);
+ERROR:  relation "no_such_table_here" does not exist
+\set VERBOSITY default
+SELECT count(*)::int AS error_row_not_inserted FROM ts_t WHERE x = 40;
+ error_row_not_inserted 
+------------------------
+                      0
+(1 row)
+
+DROP TRIGGER ts_tr6 ON ts_t;
+-- The session still works afterwards.
+SELECT 'session usable' AS after_error;
+  after_error   
+----------------
+ session usable
+(1 row)
+
+-- A statement-level trigger reaches the same path.
+CREATE FUNCTION ts_stmt() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("INSERT INTO ts_log VALUES ('statement level')");
+  return null;
+$$;
+CREATE TRIGGER ts_tr7 AFTER INSERT ON ts_t EXECUTE FUNCTION ts_stmt();
+INSERT INTO ts_t VALUES (50);
+SELECT msg FROM ts_log WHERE msg = 'statement level';
+       msg       
+-----------------
+ statement level
+(1 row)
+
+DROP TRIGGER ts_tr7 ON ts_t;
+DROP FUNCTION ts_stmt(), ts_error(), ts_ddl(), ts_cursor(), ts_prepare(), ts_insert(), ts_select();
+DROP TABLE ts_t, ts_log;

--- a/expected/pg_typedarray_views.out
+++ b/expected/pg_typedarray_views.out
@@ -1,0 +1,38 @@
+-- Typed-array -> bytea conversion, including 32-bit widths and offset views.
+--
+-- Regression test for a heap-buffer overflow in the Uint32Array / Int32Array
+-- -> bytea path in src/types.c: the copy loop iterated 4*length times while the
+-- destination held only length uint32 slots, overwriting 3*length slots past
+-- the end of the allocation. (The 8- and 16-bit paths already looped over
+-- length correctly.) The fix bounds the 32-bit loop by length. This pins the
+-- correct little-endian bytes for 8/16/32-bit views, an offset view
+-- (new Uint32Array(ab, byteOffset, n)), and that cursor.fetch still works when
+-- invoked through Function.prototype.apply.
+CREATE FUNCTION ta_u8()  RETURNS bytea LANGUAGE pljs AS $$ return new Uint8Array([1, 2, 3, 255]); $$;
+CREATE FUNCTION ta_u16() RETURNS bytea LANGUAGE pljs AS $$ return new Uint16Array([1, 258]); $$;
+CREATE FUNCTION ta_u32() RETURNS bytea LANGUAGE pljs AS $$ return new Uint32Array([1, 2, 3]); $$;
+CREATE FUNCTION ta_i32() RETURNS bytea LANGUAGE pljs AS $$ return new Int32Array([-1, 256]); $$;
+CREATE FUNCTION ta_off() RETURNS bytea LANGUAGE pljs AS $$
+  const ab = new ArrayBuffer(16);
+  const full = new Uint32Array(ab);
+  full[0] = 9; full[1] = 1; full[2] = 2; full[3] = 9;
+  return new Uint32Array(ab, 4, 2);   // view over elements 1,2 only
+$$;
+SELECT ta_u8() AS u8, ta_u16() AS u16, ta_u32() AS u32, ta_i32() AS i32, ta_off() AS off;
+     u8     |    u16     |            u32             |        i32         |        off         
+------------+------------+----------------------------+--------------------+--------------------
+ \x010203ff | \x01000201 | \x010000000200000003000000 | \xffffffff00010000 | \x0100000002000000
+(1 row)
+
+DO $$
+  const cur = pljs.prepare('SELECT 42 AS x').cursor();
+  const row = cur.fetch.apply(cur);
+  pljs.elog(NOTICE, 'fetch.apply: ' + JSON.stringify(row));
+  cur.close();
+$$ LANGUAGE pljs;
+NOTICE:  fetch.apply: {"x":42}
+DROP FUNCTION ta_u8();
+DROP FUNCTION ta_u16();
+DROP FUNCTION ta_u32();
+DROP FUNCTION ta_i32();
+DROP FUNCTION ta_off();

--- a/expected/pg_validator.out
+++ b/expected/pg_validator.out
@@ -1,0 +1,95 @@
+-- The validator must validate the function being created, and must accept a pljs
+-- body rather than requiring a standalone program.
+--
+-- Two defects, which masked each other:
+--
+--   1. It read fcinfo->flinfo->fn_oid -- its *own* OID -- and so fetched the
+--      validator's pg_proc row, whose prosrc is the C symbol name
+--      "pljs_call_validator".  That parses as a bare JavaScript identifier, so
+--      validation always succeeded and any invalid body was accepted, with the
+--      syntax error surfacing only on the first call.
+--
+--   2. Correcting the OID alone is not enough: a pljs body is a function *body*,
+--      not a program, so `return 42;` is a syntax error at top level.  Validating
+--      the raw prosrc rejects almost every valid function -- measured at 46 of 89
+--      test files failing.  The body has to be wrapped the way compilation wraps
+--      it, which is why the source builder is now shared with
+--      pljs_compile_function().
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- A syntactically invalid body is rejected at CREATE time.
+\set VERBOSITY terse
+CREATE FUNCTION val_bad() RETURNS int LANGUAGE pljs AS $$ this is ( not js $$;
+ERROR:  expecting ';'
+-- An unterminated construct, likewise.
+CREATE FUNCTION val_unclosed() RETURNS int LANGUAGE pljs AS $$ if (true) { $$;
+ERROR:  unexpected token in expression: ''
+\set VERBOSITY default
+-- Valid bodies are accepted, including the shapes that a naive "validate the raw
+-- prosrc" check would reject: a bare return, named arguments, and a trigger's
+-- implicit variables.
+CREATE FUNCTION val_return() RETURNS int LANGUAGE pljs AS $$ return 42; $$;
+CREATE FUNCTION val_args(a int, b text) RETURNS text LANGUAGE pljs AS $$
+  return b + a;
+$$;
+CREATE FUNCTION val_novoid() RETURNS void LANGUAGE pljs AS $$ pljs.elog(NOTICE, 'ok'); $$;
+SELECT val_return() AS returns_ok, val_args(1, 'x') AS args_ok;
+ returns_ok | args_ok 
+------------+---------
+         42 | x1
+(1 row)
+
+CREATE TABLE val_t (x int);
+CREATE FUNCTION val_trigger() RETURNS trigger LANGUAGE pljs AS $$
+  return NEW;
+$$;
+CREATE TRIGGER val_tr BEFORE INSERT ON val_t
+  FOR EACH ROW EXECUTE FUNCTION val_trigger();
+INSERT INTO val_t VALUES (1);
+SELECT count(*)::int AS trigger_inserted FROM val_t;
+ trigger_inserted 
+------------------
+                1
+(1 row)
+
+-- check_function_bodies = off must skip validation entirely, which is what that
+-- setting is for (restoring a dump whose functions reference objects not yet
+-- created).
+SET check_function_bodies = off;
+CREATE FUNCTION val_deferred() RETURNS int LANGUAGE pljs AS $$ this is ( not js $$;
+RESET check_function_bodies;
+-- ... and the error then surfaces on first call instead.
+\set VERBOSITY terse
+SELECT val_deferred();
+ERROR:  expecting ';'
+\set VERBOSITY default
+-- Replacing a function repeatedly must not accumulate anything: the DDL path used
+-- to reset the entire context cache, which could not free the old contexts, so a
+-- loop of CREATE OR REPLACE grew the backend without bound and then crashed it.
+-- 200 replacements is far too few to show the growth, but it does prove the
+-- invalidation itself works -- each call must see the new body.
+CREATE FUNCTION val_churn(n int) RETURNS int LANGUAGE plpgsql AS $$
+DECLARE i int; r int; bad int := 0;
+BEGIN
+  FOR i IN 1..n LOOP
+    EXECUTE format('CREATE OR REPLACE FUNCTION val_v() RETURNS int LANGUAGE pljs AS $b$ return %s; $b$', i);
+    EXECUTE 'SELECT val_v()' INTO r;
+    IF r <> i THEN bad := bad + 1; END IF;
+  END LOOP;
+  RETURN bad;
+END $$;
+SELECT val_churn(200) AS stale_results;
+ stale_results 
+---------------
+             0
+(1 row)
+
+DROP FUNCTION val_churn(int);
+DROP FUNCTION val_v();
+DROP TRIGGER val_tr ON val_t;
+DROP FUNCTION val_trigger();
+DROP TABLE val_t;
+DROP FUNCTION val_return();
+DROP FUNCTION val_args(int, text);
+DROP FUNCTION val_novoid();
+DROP FUNCTION val_deferred();

--- a/expected/start_proc.out
+++ b/expected/start_proc.out
@@ -20,7 +20,7 @@ SET ROLE new_context;
 SET pljs.start_proc = 'end';
 DO $$ pljs.elog(NOTICE, pljs.current_scope.name); $$ language pljs;
 WARNING:  failed to find pljs function function "end" does not exist: 
-ERROR:  execution error
+ERROR:  cannot read property 'name' of undefined
 DETAIL:  TypeError: cannot read property 'name' of undefined
     at <anonymous> (<function>:1:52)
     at <eval> (<function>:1:62)

--- a/expected/types.out
+++ b/expected/types.out
@@ -69,12 +69,14 @@ SELECT text_to_int4('123');
           123
 (1 row)
 
+-- A string is parsed by int4's input function, so text that is not an integer
+-- raises instead of silently becoming 0, which is what routing it through a
+-- double produced.
 SELECT text_to_int4('abc');
- text_to_int4 
---------------
-            0
-(1 row)
-
+ERROR:  invalid input syntax for type integer: "abc"
+-- Out of range likewise raises rather than wrapping.
+SELECT text_to_int4('2147483648');
+ERROR:  value "2147483648" is out of range for type integer
 -- ARRAYS
 CREATE FUNCTION return_array() RETURNS TEXT[] AS $$ return ["foo", "bar"]; $$LANGUAGE pljs;
 SELECT return_array();

--- a/expected/types.out
+++ b/expected/types.out
@@ -107,7 +107,7 @@ CREATE OR REPLACE FUNCTION bigint_failing(val BIGINT)
     return val - 1;
    $$ LANGUAGE pljs STABLE STRICT;
 SELECT bigint_failing(9223372036854775807);
-ERROR:  execution error
+ERROR:  cannot convert bigint to number
 DETAIL:  TypeError: cannot convert bigint to number
     at bigint_failing (<function>:3:16)
 

--- a/expected/window.out
+++ b/expected/window.out
@@ -354,7 +354,7 @@ CREATE FUNCTION bad_alloc(sz text) RETURNS void AS $$
   winobj.set_partition_local(context);
 $$ LANGUAGE pljs WINDOW;
 SELECT bad_alloc('5') OVER ();
-ERROR:  execution error
+ERROR:  window local memory overflow
 DETAIL:  Error: window local memory overflow
     at bad_alloc (<function>:6:29)
 
@@ -374,7 +374,7 @@ CREATE FUNCTION non_window() RETURNS void AS $$
   var winobj = pljs.get_window_object();
 $$ LANGUAGE pljs;
 SELECT non_window();
-ERROR:  execution error
+ERROR:  get_window_object called in wrong context
 DETAIL:  Error: get_window_object called in wrong context
     at non_window (<function>:3:38)
 

--- a/sql/pg_cancellation.sql
+++ b/sql/pg_cancellation.sql
@@ -1,0 +1,41 @@
+-- Regression: pljs must honor query cancellation / statement_timeout.
+--
+-- Previously _PG_init() installed its own signal(SIGINT/SIGTERM/SIGABRT)
+-- handlers, clobbering PostgreSQL's own signal handling for the whole backend,
+-- and the QuickJS interrupt handler only consulted pljs's private
+-- os_pending_signals bitmask.  statement_timeout is delivered via SIGALRM ->
+-- QueryCancelPending, which that bitmask never saw, so a runaway JS loop could
+-- not be cancelled and the backend hung forever.  The interrupt handler now
+-- reads QueryCancelPending/ProcDiePending directly, and each caller re-raises
+-- the real error via CHECK_FOR_INTERRUPTS() once QuickJS has unwound to an
+-- exception.  These tests must complete (with a cancel error) instead of
+-- hanging.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- A runaway loop in an anonymous DO block (call_anonymous_function path) must
+-- be cancelled by statement_timeout.
+SET statement_timeout = '400ms';
+DO $$ var x = 0; while (true) { x++; } $$ LANGUAGE pljs;
+RESET statement_timeout;
+
+-- ... and in a regular function (call_function path).
+CREATE FUNCTION spin() RETURNS int LANGUAGE pljs AS $$
+  var x = 0;
+  while (true) { x++; }
+  return x;
+$$;
+SET statement_timeout = '400ms';
+SELECT spin();
+RESET statement_timeout;
+
+-- The backend survived both cancellations and is still usable.
+SELECT 1 AS alive;
+
+-- A normal JS error must NOT be masked by the interrupt check (no cancel is
+-- pending, so CHECK_FOR_INTERRUPTS() is a no-op and the real JS error surfaces).
+DO $$
+  try { throw new Error('plain error'); }
+  catch (e) { pljs.elog(NOTICE, 'caught: ' + e.message); }
+$$ LANGUAGE pljs;
+
+DROP FUNCTION spin();

--- a/sql/pg_column_name_mismatch.sql
+++ b/sql/pg_column_name_mismatch.sql
@@ -1,0 +1,61 @@
+-- The column/property mismatch error says which column and what was offered.
+--
+-- return_next() on a composite set raised a bare "field name / property name
+-- mismatch", which gave the function author nothing to act on: not which column
+-- was missing, and not what the object actually contained.  For a wide RETURNS
+-- TABLE that meant reading the whole declaration against the whole object by eye.
+--
+-- The overwhelmingly common cause is a case difference -- JavaScript property
+-- names are case sensitive while PostgreSQL folds unquoted identifiers to lower
+-- case, so a `MixedCol` key never matches a `mixedcol` column, and the two look
+-- identical at a glance.  Naming both sides makes that immediate.
+--
+-- Note this deliberately stays an error rather than filling the column with NULL.
+-- NULL-filling would make a typo'd or wrong-case key silently produce a NULL
+-- column, turning a loud, fixable mistake into exactly the kind of silent data
+-- loss the rest of these fixes exist to remove.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- 1) a genuinely missing column names itself and lists what was provided.
+CREATE FUNCTION cnm_missing() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({a: 1});
+$$;
+SELECT * FROM cnm_missing();
+
+-- 2) the case-mismatch case, which is what this is really for.
+CREATE FUNCTION cnm_case() RETURNS TABLE(mixedcol int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({MixedCol: 7, b: 'x'});
+$$;
+SELECT * FROM cnm_case();
+
+-- 3) an object with no properties at all.
+CREATE FUNCTION cnm_empty() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({});
+$$;
+SELECT * FROM cnm_empty();
+
+-- 4) the first missing column is the one reported, even when several are absent.
+CREATE FUNCTION cnm_several() RETURNS TABLE(alpha int, beta text, gamma int)
+LANGUAGE pljs AS $$
+  pljs.return_next({beta: 'only this one'});
+$$;
+SELECT * FROM cnm_several();
+
+-- 5) the error is catchable in JavaScript and carries the detail.
+DO $$
+  try {
+    pljs.execute('SELECT * FROM cnm_case()');
+    pljs.elog(NOTICE, 'unexpectedly succeeded');
+  } catch (e) {
+    pljs.elog(NOTICE, 'names the column: ' + (e.message.indexOf('mixedcol') >= 0));
+    pljs.elog(NOTICE, 'lists the keys: ' + (e.message.indexOf('MixedCol') >= 0));
+  }
+$$ LANGUAGE pljs;
+
+-- 6) a complete object still works, and extra properties remain ignored.
+CREATE FUNCTION cnm_ok() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next({a: 1, b: 'x', extra: 'ignored'});
+$$;
+SELECT a, b FROM cnm_ok();
+
+DROP FUNCTION cnm_missing, cnm_case, cnm_empty, cnm_several, cnm_ok;

--- a/sql/pg_column_name_mismatch.sql
+++ b/sql/pg_column_name_mismatch.sql
@@ -59,3 +59,17 @@ $$;
 SELECT a, b FROM cnm_ok();
 
 DROP FUNCTION cnm_missing, cnm_case, cnm_empty, cnm_several, cnm_ok;
+
+-- The provided-key list is capped.  An object with thousands of properties would
+-- otherwise put every name into the message, which lands in the server log as
+-- well as the client; ten names plus the total is enough to spot a typo.
+CREATE FUNCTION cnm_many() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  const row = {};
+  for (let i = 0; i < 500; i++) row['prop' + i] = i;
+  pljs.return_next(row);
+$$;
+
+SELECT * FROM cnm_many();
+
+DROP FUNCTION cnm_many();
+

--- a/sql/pg_composite_null_datum.sql
+++ b/sql/pg_composite_null_datum.sql
@@ -1,0 +1,71 @@
+-- Regression: a composite column that converts to NULL crashed the backend.
+--
+-- pljs_jsvalue_to_datum() signalled a SQL NULL with PG_RETURN_NULL(), which
+-- expands to `fcinfo->isnull = true; return (Datum) 0`.  Every column of a
+-- composite is converted through pljs_jsvalue_to_datums() or
+-- pljs_jsvalue_to_record(), and both pass fcinfo == NULL -- they report the null
+-- through the is_null argument instead.  Each of those sites therefore wrote
+-- through a null pointer: a SIGSEGV on address 0x1c, which is the offset of
+-- FunctionCallInfoBaseData.isnull.
+--
+-- Reaching it takes nothing exotic.  `case DATEOID` handles only a JavaScript
+-- Date and breaks out of the switch for anything else, so a plain string for a
+-- date column falls through to the trailing null return.  The scalar form of the
+-- same conversion has a real fcinfo and quietly returns NULL, which is why this
+-- stayed hidden: `RETURNS date` is fine, and only the composite form dies.
+CREATE TYPE cnd_row AS (d date, ts timestamp, n int);
+
+-- Through return_next() on a set.
+CREATE FUNCTION cnd_set() RETURNS SETOF cnd_row AS $$
+  pljs.return_next({ d: 'not-a-date', ts: 'not-a-timestamp', n: 1 });
+$$ LANGUAGE pljs;
+
+SELECT * FROM cnd_set();
+
+-- Through a plain composite return, which takes pljs_jsvalue_to_record().
+CREATE FUNCTION cnd_record() RETURNS cnd_row AS $$
+  return { d: 'not-a-date', ts: 42, n: 2 };
+$$ LANGUAGE pljs;
+
+SELECT * FROM cnd_record();
+
+-- An array column reaches the same path one level deeper: the element conversion
+-- is handed the caller's fcinfo, which is NULL here too.
+CREATE TYPE cnd_arr AS (a date[]);
+
+CREATE FUNCTION cnd_array() RETURNS cnd_arr AS $$
+  return { a: ['not-a-date'] };
+$$ LANGUAGE pljs;
+
+SELECT * FROM cnd_array();
+
+-- A valid date string takes the same path, because the check is Is_Date() and not
+-- a parse: it becomes NULL rather than 2020-01-01.  Recorded here as the current
+-- behaviour, not endorsed -- routing these through the type's input function is a
+-- change of semantics and belongs with the rest of the type I/O work.
+CREATE FUNCTION cnd_valid_string() RETURNS cnd_row AS $$
+  return { d: '2020-01-01', ts: '2020-01-01 12:00:00', n: 3 };
+$$ LANGUAGE pljs;
+
+SELECT * FROM cnd_valid_string();
+
+-- A real Date still converts, so the fix did not disturb the working path.
+CREATE FUNCTION cnd_real_date() RETURNS cnd_row AS $$
+  return { d: new Date(Date.UTC(2020, 0, 1)), ts: new Date(Date.UTC(2020, 0, 1, 12)), n: 4 };
+$$ LANGUAGE pljs;
+
+-- Compared rather than printed: the rendering of a date depends on DateStyle.
+SELECT (r).d = DATE '2020-01-01'                        AS date_converts,
+       (r).ts = TIMESTAMP '2020-01-01 12:00:00'         AS timestamp_converts,
+       (r).n                                            AS n
+  FROM cnd_real_date() r;
+
+-- The scalar path, which always had a real fcinfo, is unchanged.
+CREATE FUNCTION cnd_scalar() RETURNS date AS $$ return 'not-a-date'; $$ LANGUAGE pljs;
+
+SELECT cnd_scalar() IS NULL AS scalar_still_null;
+
+SELECT 1 AS alive;
+
+DROP FUNCTION cnd_set, cnd_record, cnd_array, cnd_valid_string, cnd_real_date, cnd_scalar;
+DROP TYPE cnd_row, cnd_arr;

--- a/sql/pg_cross_backend_invalidation.sql
+++ b/sql/pg_cross_backend_invalidation.sql
@@ -1,0 +1,55 @@
+-- A function replaced by *another* backend must not keep running the old body
+-- here.
+--
+-- pljs caches the compiled function per (user, OID) and registers no syscache
+-- invalidation callback, so nothing tells this backend that the definition
+-- changed.  The validator drops the entry directly, which covers only the backend
+-- that issued the DDL.  Every other session that had already called the function
+-- went on running the body it first compiled, for the rest of its life, however
+-- many times the function was replaced.
+--
+-- pljs_func already declared fn_xmin and fn_tid for this purpose; nothing ever
+-- wrote or read them.  They are now recorded at compile time and checked on every
+-- cache hit, which is what plpgsql does (see plpgsql_compile()).  CREATE OR
+-- REPLACE writes a new pg_proc tuple version while keeping the OID, so the
+-- mismatch is what makes the staleness visible.
+--
+-- The second backend comes from \!.  psql inherits PGHOST/PGPORT from pg_regress
+-- and finds psql on PATH via --bindir, but \! does not interpolate psql
+-- variables, so the database name is handed over through the environment with
+-- \setenv rather than hardcoded.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+\setenv PGDATABASE :DBNAME
+
+CREATE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 1; $$;
+
+-- Compile and cache it in this backend.
+SELECT xb_fn() AS first_call;
+
+-- Replaced elsewhere.  Without the xmin/tid check this reports 1 forever.
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 2; $$'
+SELECT xb_fn() AS after_other_backend_replaced_it;
+
+-- Again, to show it is not a one-shot invalidation.
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 3; $$'
+SELECT xb_fn() AS after_second_replacement;
+
+-- A changed signature, not just a changed body: the argument list is part of what
+-- the cache entry carries.
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_fn() RETURNS int LANGUAGE pljs AS $$ return 40 + 2; $$'
+SELECT xb_fn() AS after_body_rewrite;
+
+-- Same check for a function this backend reaches through pljs.find_function(),
+-- which is the other cache lookup site.
+CREATE FUNCTION xb_target() RETURNS int LANGUAGE pljs AS $$ return 10; $$;
+CREATE FUNCTION xb_caller() RETURNS int LANGUAGE pljs AS $$
+  return pljs.find_function('xb_target')();
+$$;
+SELECT xb_caller() AS caller_first;
+\! psql -X -q -c 'CREATE OR REPLACE FUNCTION xb_target() RETURNS int LANGUAGE pljs AS $$ return 20; $$'
+SELECT xb_caller() AS caller_after_replacement;
+
+DROP FUNCTION xb_caller();
+DROP FUNCTION xb_target();
+DROP FUNCTION xb_fn();

--- a/sql/pg_cursor_error_recovery.sql
+++ b/sql/pg_cursor_error_recovery.sql
@@ -1,0 +1,33 @@
+-- Regression: the cursor fetch/move/close error handlers used to call
+-- SPI_rollback() + SPI_finish().  In an atomic context SPI_rollback() raises
+-- "invalid transaction termination", masking the real error, and SPI_finish()
+-- double-finishes the SPI connection owned by call_function.  The handlers now
+-- guard the operation with an internal subtransaction (same pattern as
+-- pljs.execute), so the real error is rolled back cleanly and re-raised into
+-- JS where it is catchable.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- A cursor whose query raises division-by-zero lazily during the scan, so the
+-- error fires inside SPI_cursor_fetch().
+CREATE FUNCTION cur_err() RETURNS text LANGUAGE pljs AS $$
+  var p = pljs.prepare("SELECT 1 / (5 - i) AS v FROM generate_series(1,10) i");
+  var c = p.cursor();
+  try {
+    for (var k = 0; k < 10; k++) {
+      var row = c.fetch();
+      if (row === undefined) break;
+    }
+  } catch (e) {
+    return "caught: " + e.message;
+  }
+  return "no error";
+$$;
+
+-- Expect the real error surfaced to JS, not "invalid transaction termination".
+SELECT cur_err();
+
+-- Backend and SPI are intact; the same function runs again.
+SELECT cur_err();
+SELECT 1 AS alive;
+
+DROP FUNCTION cur_err();

--- a/sql/pg_cursor_plan_lifetime.sql
+++ b/sql/pg_cursor_plan_lifetime.sql
@@ -1,0 +1,93 @@
+-- Cursor/plan lifetime: a cursor must keep its plan alive.
+--
+-- pljs_plan_handle_finalizer() calls SPI_freeplan(), and it runs as soon as the
+-- plan handle becomes unreachable.  The natural idiom makes that immediate,
+-- because QuickJS is refcount-primary -- the temporary plan object's count drops
+-- to zero the moment .cursor() returns:
+--
+--     var c = pljs.prepare('select ... where id = $1', ['int']).cursor([1]);
+--     while (c.fetch()) { ... }
+--
+-- SPI_freeplan -> DropCachedPlan sets plansource->magic = 0 and deletes the
+-- plansource's context, while the portal opened from it is still live and gets
+-- re-entered by fetch/move/close.  SPI_freeplan's own contract says a plan in
+-- use must not be freed.
+--
+-- HONEST NOTE ON WHAT THIS TEST PROVES: it does not discriminate.  All three
+-- cases below pass with and without the fix, on a build that has
+-- CLOBBER_FREED_MEMORY enabled (--enable-cassert defines it), including after
+-- deliberately churning plancache and palloc memory to encourage reuse of the
+-- freed plansource.  The portal holds a refcount on the CachedPlan rather than
+-- on the CachedPlanSource and does not appear to dereference the plansource
+-- during a fetch, so the contract violation does not surface as a crash here.
+--
+-- The tests are kept because they pin the observable behaviour -- correct row
+-- counts across GC and across an explicit free -- so a future change that breaks
+-- cursors outright is caught.  The fix itself is justified by SPI's contract, not
+-- by a reproduction.
+CREATE FUNCTION curlife_gc() RETURNS int AS $$
+  // The plan is unreachable immediately after .cursor() returns.
+  const c = pljs.prepare('SELECT i FROM generate_series(1, 50) i', []).cursor([]);
+  pljs.gc();
+  pljs.gc();
+  let n = 0;
+  while (c.fetch()) n++;
+  c.close();
+  return n;
+$$ LANGUAGE pljs;
+
+SELECT curlife_gc() AS rows_after_gc;
+
+-- An explicit free() while the cursor is open must not corrupt memory.  It
+-- currently still returns rows; pljs_plan_free()'s JS_SetOpaque(ptr, NULL) is
+-- what stops the finalizer double-freeing afterwards.
+CREATE FUNCTION curlife_explicit_free() RETURNS text AS $$
+  const p = pljs.prepare('SELECT i FROM generate_series(1, 50) i', []);
+  const c = p.cursor([]);
+  p.free();
+  try {
+    let n = 0;
+    while (c.fetch()) n++;
+    c.close();
+    return 'fetched ' + n;
+  } catch (e) {
+    return 'raised: ' + e.message;
+  }
+$$ LANGUAGE pljs;
+
+SELECT curlife_explicit_free() AS after_explicit_free;
+
+-- Same as the first case, but churning plancache and palloc memory between the
+-- collection and the fetch, which is the shape most likely to reuse a freed
+-- plansource.
+CREATE FUNCTION curlife_churn() RETURNS int AS $$
+  const c = pljs.prepare('SELECT i FROM generate_series(1, 200) i', []).cursor([]);
+  pljs.gc();
+  for (let i = 0; i < 200; i++) {
+    pljs.execute('SELECT repeat($1, 50) AS r', ['x' + i]);
+    const p2 = pljs.prepare('SELECT $1::int AS v', ['int4']);
+    p2.execute([i]);
+    p2.free();
+  }
+  pljs.gc();
+  let n = 0;
+  while (c.fetch()) n++;
+  c.close();
+  return n;
+$$ LANGUAGE pljs;
+
+SELECT curlife_churn() AS rows_after_churn;
+
+-- move() and close() go through the same portal, so exercise them too.
+CREATE FUNCTION curlife_move() RETURNS int AS $$
+  const c = pljs.prepare('SELECT i FROM generate_series(1, 100) i', []).cursor([]);
+  pljs.gc();
+  c.move(10);
+  const row = c.fetch();
+  c.close();
+  return row.i;
+$$ LANGUAGE pljs;
+
+SELECT curlife_move() AS row_after_move;
+
+DROP FUNCTION curlife_gc, curlife_explicit_free, curlife_churn, curlife_move;

--- a/sql/pg_error_envelope_fields.sql
+++ b/sql/pg_error_envelope_fields.sql
@@ -1,0 +1,85 @@
+-- This file is coverage rather than a regression test.  The change it accompanies
+-- collapses six copies of one ereport into a single helper and deliberately alters no
+-- behaviour, so every assertion below passes with and without it.  They are here to
+-- pin the envelope a caller actually programs against -- message, detail, hint and
+-- the SQLSTATE -- so that a later change to any one report site cannot quietly drop
+-- a field.
+-- The structured half of the error envelope: that a SQL error raised inside
+-- pljs.execute() reaches JavaScript as an Error carrying message, detail, hint
+-- and the SQLSTATE, and that those survive a try/catch.
+--
+-- The error text alone is not what a caller programs against: code that reacts to a
+-- failure reads the SQLSTATE and, where present, the detail and hint.  Those are
+-- asserted here, including that they survive being caught in JavaScript, because text
+-- is easy to check by eye and the structured fields are not.
+CREATE FUNCTION eenv_fields() RETURNS text AS $$
+  try {
+    pljs.execute('SELECT 1/0');
+    return 'no error';
+  } catch (e) {
+    return 'message=' + (e.message || '(none)') +
+           ' sqlstate=' + (e.sqlstate || '(none)') +
+           ' sqlerrcode=' + (e.sqlerrcode || '(none)');
+  }
+$$ LANGUAGE pljs;
+
+SELECT eenv_fields() AS division_by_zero;
+
+-- detail and hint are carried across when the underlying error has them.
+CREATE TABLE eenv_t (id int PRIMARY KEY);
+INSERT INTO eenv_t VALUES (1);
+
+CREATE FUNCTION eenv_detail() RETURNS text AS $$
+  try {
+    pljs.execute('INSERT INTO eenv_t VALUES (1)');
+    return 'no error';
+  } catch (e) {
+    return 'sqlstate=' + e.sqlstate +
+           ' has_detail=' + (e.detail ? 'yes' : 'no') +
+           ' message_mentions_key=' + (/eenv_t_pkey/.test(e.message) ? 'yes' : 'no');
+  }
+$$ LANGUAGE pljs;
+
+SELECT eenv_detail() AS unique_violation;
+
+-- A specific SQLSTATE can be dispatched on, which is the point of exposing it.
+CREATE FUNCTION eenv_dispatch() RETURNS text AS $$
+  try {
+    pljs.execute('INSERT INTO eenv_t VALUES (1)');
+    return 'no error';
+  } catch (e) {
+    if (e.sqlstate === '23505') return 'caught unique_violation by sqlstate';
+    return 'unexpected sqlstate: ' + e.sqlstate;
+  }
+$$ LANGUAGE pljs;
+
+SELECT eenv_dispatch() AS dispatched;
+
+-- A user-defined error keeps its own message rather than being flattened to
+-- "execution error", including across a nested pljs.execute() boundary.
+CREATE FUNCTION eenv_inner() RETURNS int AS $$
+  throw new Error('[E123] inner failed');
+$$ LANGUAGE pljs;
+
+CREATE FUNCTION eenv_nested() RETURNS text AS $$
+  try {
+    pljs.execute('SELECT eenv_inner()');
+    return 'no error';
+  } catch (e) {
+    return 'preserved=' + (e.message.indexOf('[E123]') >= 0 ? 'yes' : 'no') +
+           ' message=' + e.message;
+  }
+$$ LANGUAGE pljs;
+
+SELECT eenv_nested() AS nested_user_error;
+
+-- An error with an empty message must not produce an error with no text: the
+-- fallback is what pljs_ereport_js_error() guards, at every report site.
+CREATE FUNCTION eenv_empty() RETURNS int AS $$
+  throw new Error('');
+$$ LANGUAGE pljs;
+
+SELECT eenv_empty();
+
+DROP FUNCTION eenv_fields, eenv_detail, eenv_dispatch, eenv_nested, eenv_inner, eenv_empty;
+DROP TABLE eenv_t;

--- a/sql/pg_error_sqlstate.sql
+++ b/sql/pg_error_sqlstate.sql
@@ -1,0 +1,47 @@
+-- pljs hands the SQLSTATE of a PostgreSQL error to JavaScript as e.sqlstate: the
+-- five-character string, under the name every other procedural language uses and
+-- the one a JavaScript author reaches for.  e.sqlerrcode stays as an alias, since
+-- code already written against it must keep working.
+CREATE FUNCTION esq_fields() RETURNS text AS $$
+  try {
+    pljs.execute('SELECT 1/0');
+  } catch (e) {
+    return 'sqlstate=' + e.sqlstate + ' sqlerrcode=' + e.sqlerrcode;
+  }
+  return 'no error';
+$$ LANGUAGE pljs;
+
+SELECT esq_fields() AS division_by_zero;
+
+-- Dispatching on the value is the reason for exposing it.
+CREATE TABLE esq_t (id int PRIMARY KEY);
+INSERT INTO esq_t VALUES (1);
+
+CREATE FUNCTION esq_dispatch() RETURNS text AS $$
+  try {
+    pljs.execute('INSERT INTO esq_t VALUES (1)');
+  } catch (e) {
+    if (e.sqlstate === '23505') {
+      return 'unique_violation, dispatched on sqlstate';
+    }
+    return 'unexpected sqlstate: ' + e.sqlstate;
+  }
+  return 'no error';
+$$ LANGUAGE pljs;
+
+SELECT esq_dispatch() AS dispatched;
+
+-- An error raised by RAISE in SQL keeps the SQLSTATE it was given.
+CREATE FUNCTION esq_raised() RETURNS text AS $$
+  try {
+    pljs.execute("DO $x$ BEGIN RAISE EXCEPTION 'nope' USING ERRCODE = '22023'; END $x$");
+  } catch (e) {
+    return 'sqlstate=' + e.sqlstate;
+  }
+  return 'no error';
+$$ LANGUAGE pljs;
+
+SELECT esq_raised() AS explicit_errcode;
+
+DROP FUNCTION esq_fields, esq_dispatch, esq_raised;
+DROP TABLE esq_t;

--- a/sql/pg_errordata_stack.sql
+++ b/sql/pg_errordata_stack.sql
@@ -1,0 +1,94 @@
+-- Every PG_CATCH that reports a Postgres error to JavaScript must call
+-- FlushErrorState().  Returning without it leaves the entry on the errordata
+-- stack, which is only ERRORDATA_STACK_SIZE (5) deep and is not unwound until
+-- the enclosing statement ends, so the sixth caught error inside a single call
+-- raises "PANIC: ERRORDATA_STACK_SIZE exceeded" -- killing every backend in the
+-- cluster, not just this session.
+--
+-- pljs_execute() was fixed for this earlier; pljs.commit(), pljs.rollback(),
+-- pljs.find_function() and plan.cursor() were not.  Each loop below caught 12
+-- errors, well past the limit, and PANICked.  A mirror procedure that retries a
+-- failing commit (deadlock, serialization failure, full disk) reaches this.
+--
+-- These handlers also used to discard the real error behind a fixed string
+-- ("Unable to commit", "Error executing"), so the tests assert the actual
+-- Postgres message survives.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- 1) pljs.commit() inside a non-atomic context fails every time.
+CREATE FUNCTION errstack_commit(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  for (var i = 0; i < n; i++) {
+    try { pljs.commit(); } catch (e) { caught++; last = e.message; }
+  }
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+
+SELECT errstack_commit(12);
+
+-- 2) pljs.rollback(), same context.
+CREATE FUNCTION errstack_rollback(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  for (var i = 0; i < n; i++) {
+    try { pljs.rollback(); } catch (e) { caught++; last = e.message; }
+  }
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+
+SELECT errstack_rollback(12);
+
+-- 3) pljs.find_function() on a name that does not exist.
+CREATE FUNCTION errstack_find_function(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  for (var i = 0; i < n; i++) {
+    try { pljs.find_function('pljs_no_such_function'); }
+    catch (e) { caught++; last = e.message; }
+  }
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+
+SELECT errstack_find_function(12);
+
+-- 4) plan.cursor(): opening a cursor runs the query's start-up, so it fails
+-- here on division by zero.  Two things are asserted: the loop survives, and
+-- the real error reaches JavaScript instead of the old opaque "Error executing".
+--
+-- The open path also had no internal subtransaction, so everything each failed
+-- attempt acquired leaked until end of transaction; 200 iterations used to emit
+-- 200 "WARNING: resource was not closed: cache pg_proc ... has count N" lines.
+-- A clean result here is the regression signal for that too.
+CREATE FUNCTION errstack_cursor(n int) RETURNS text AS $$
+  var caught = 0, last = '';
+  var plan = pljs.prepare('SELECT 1 / $1::int AS v', ['int']);
+  for (var i = 0; i < n; i++) {
+    try { plan.cursor([0]); } catch (e) { caught++; last = e.message; }
+  }
+  plan.free();
+  return caught + ' caught, last: ' + last;
+$$ LANGUAGE pljs;
+
+SELECT errstack_cursor(200);
+
+-- A cursor that opens successfully still works, and is still usable after the
+-- subtransaction that guarded its open was released.
+DO $$
+  var plan = pljs.prepare('SELECT g FROM generate_series(1, 5) g WHERE g > $1', ['int']);
+  var cursor = plan.cursor([2]);
+  var rows = [], row;
+
+  while ((row = cursor.fetch()) !== undefined) {
+    rows.push(row.g);
+  }
+
+  cursor.close();
+  plan.free();
+  pljs.elog(NOTICE, 'cursor rows after guarded open: ' + rows.join(','));
+$$ LANGUAGE pljs;
+
+-- The backend is still alive and the errordata stack is clean.
+SELECT 'backend still usable' AS status, 1 + 1 AS math;
+
+DROP FUNCTION errstack_commit(int);
+DROP FUNCTION errstack_rollback(int);
+DROP FUNCTION errstack_find_function(int);
+DROP FUNCTION errstack_cursor(int);

--- a/sql/pg_find_function_no_perm.sql
+++ b/sql/pg_find_function_no_perm.sql
@@ -1,0 +1,41 @@
+-- Regression for a backend crash: pljs.find_function() on a function the
+-- caller lacks EXECUTE permission on used to `return` from *inside* a PG_TRY
+-- block.  That left PG_exception_stack pointing at a dead stack frame, so the
+-- next ereport(ERROR) siglongjmp()'d into freed memory and the whole backend
+-- segfaulted (signal 11).  This test drives that exact sequence and must
+-- complete with a clean error instead of crashing.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+CREATE FUNCTION ff_secret() RETURNS int LANGUAGE sql AS 'SELECT 42';
+REVOKE ALL ON FUNCTION ff_secret() FROM PUBLIC;
+
+CREATE ROLE ff_limited;
+
+-- Call find_function on a function we lack EXECUTE on (the permission-denied
+-- path), then force an *unwrapped* elog(ERROR) via an int[] return of a
+-- non-array value.  Pre-fix this crashed the backend.
+CREATE FUNCTION ff_probe() RETURNS int[] LANGUAGE pljs AS $$
+  try { pljs.find_function('ff_secret()'); } catch (e) { }
+  return 5;
+$$;
+GRANT EXECUTE ON FUNCTION ff_probe() TO ff_limited;
+
+SET ROLE ff_limited;
+-- Expect a clean "value is not an Array" error, NOT a crash.
+SELECT ff_probe();
+RESET ROLE;
+
+-- The backend is still alive and usable.
+SELECT 1 AS alive;
+
+-- The permission-denied fall-through path on its own (find_function returns
+-- undefined) followed by more work must also not crash.
+SET ROLE ff_limited;
+DO $$ pljs.find_function('ff_secret()'); pljs.elog(NOTICE, 'survived'); $$ LANGUAGE pljs;
+RESET ROLE;
+
+SELECT 1 AS still_alive;
+
+DROP FUNCTION ff_probe();
+DROP FUNCTION ff_secret();
+DROP ROLE ff_limited;

--- a/sql/pg_find_function_refcount.sql
+++ b/sql/pg_find_function_refcount.sql
@@ -1,0 +1,63 @@
+-- pljs.find_function() must hand JavaScript a reference it owns.
+--
+-- The compiled function lives in the per-user cache, which is its only owner.
+-- pljs_function_cache_to_context() borrows that reference, and
+-- pljs_find_js_function() returned the borrowed value straight to the JS caller --
+-- but a JSValue returned from a C function belongs to the caller, so the engine
+-- decremented a count nobody had incremented.  After enough lookups the refcount
+-- reached zero while the entry was still cached, and the next call through the
+-- cache terminated the backend:
+--
+--   SELECT ff_loop(1000);
+--   server closed the connection unexpectedly
+--
+-- Present on stock upstream too (reproduced on 9ec6f7f).  Mixing a plain call to
+-- the target in among the lookups is what makes it fire quickly, which is why the
+-- ordering below is deliberate rather than incidental.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+CREATE FUNCTION ffr_target() RETURNS int LANGUAGE pljs AS $$ return 7; $$;
+
+CREATE FUNCTION ffr_loop(n int) RETURNS int LANGUAGE pljs AS $$
+  let total = 0;
+  for (let i = 0; i < n; i++) {
+    const f = pljs.find_function('ffr_target');
+    total += f();
+  }
+  return total;
+$$;
+
+SELECT ffr_loop(10) AS lookups_10;
+-- A direct call in between, which is what drove the refcount down fastest.
+SELECT ffr_target() AS direct_call;
+SELECT ffr_loop(2000) AS lookups_2000;
+SELECT ffr_target() AS direct_call_after;
+
+-- Release the handed-out references and collect, then use the cache again.  If the
+-- cached value had been freed, this is where it would be noticed.
+CREATE FUNCTION ffr_gc() RETURNS int LANGUAGE pljs AS $$
+  for (let i = 0; i < 2000; i++) { pljs.find_function('ffr_target'); }
+  if (typeof pljs.gc === 'function') { pljs.gc(); }
+  return pljs.find_function('ffr_target')();
+$$;
+SELECT ffr_gc() AS after_gc;
+SELECT ffr_target() AS direct_call_after_gc;
+
+-- Looking up a function that is replaced between lookups, so the entry is dropped
+-- while references to the old compiled value are still outstanding.
+CREATE FUNCTION ffr_churn() RETURNS int LANGUAGE pljs AS $$
+  let last = 0;
+  for (let i = 0; i < 50; i++) {
+    const f = pljs.find_function('ffr_target');
+    last = f();
+    pljs.execute("CREATE OR REPLACE FUNCTION ffr_target() RETURNS int LANGUAGE pljs AS $b$ return 7; $b$");
+  }
+  return last;
+$$;
+SELECT ffr_churn() AS replaced_between_lookups;
+SELECT ffr_target() AS still_callable;
+
+DROP FUNCTION ffr_churn();
+DROP FUNCTION ffr_gc();
+DROP FUNCTION ffr_loop(int);
+DROP FUNCTION ffr_target();

--- a/sql/pg_flush_error_state.sql
+++ b/sql/pg_flush_error_state.sql
@@ -1,0 +1,19 @@
+-- Regression test for the errordata-stack leak in pljs_execute's PG_CATCH.
+--
+-- When pljs.execute() caught a PostgreSQL error it copied the error data and
+-- returned a JS exception but never called FlushErrorState(), so each catch
+-- leaked one errordata_stack_depth slot. ERRORDATA_STACK_SIZE is 5, so after a
+-- few caught errors in one backend the next ereport() -- even a NOTICE --
+-- PANICs with "ERRORDATA_STACK_SIZE exceeded", taking the whole postmaster into
+-- recovery. The fix mirrors pljs_elog(): CopyErrorData -> FlushErrorState ->
+-- FreeErrorData. This loops through 12 caught errors (well past the limit of 5)
+-- and then runs a valid query and a NOTICE; without the fix the backend dies
+-- before this completes.
+DO $$
+  let caught = 0;
+  for (let i = 0; i < 12; i++) {
+    try { pljs.execute('SELECT 1/0'); } catch (e) { caught++; }
+  }
+  pljs.elog(NOTICE, 'caught ' + caught + ' errors; backend alive');
+  pljs.elog(NOTICE, 'after: ' + pljs.execute('SELECT 42 AS x')[0].x);
+$$ LANGUAGE pljs;

--- a/sql/pg_memory_limit_set.sql
+++ b/sql/pg_memory_limit_set.sql
@@ -1,0 +1,35 @@
+-- Regression: SET pljs.memory_limit at runtime must re-apply the cap to the
+-- live QuickJS runtime.
+--
+-- pljs.memory_limit was only consulted in _PG_init when the runtime was first
+-- created, so a plain SET after pljs had been used updated the GUC but not the
+-- interpreter -- you could not tighten (or loosen) the JS heap cap of a running
+-- backend.  An assign hook now re-applies JS_SetMemoryLimit() on every change.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- Set the cap *before* the first pljs execution so the runtime is created at
+-- 300MB regardless of any cluster-wide default; this makes the runtime SETs
+-- below unambiguous.
+SET pljs.memory_limit = 300;
+
+-- Catch the allocation error in JS so the (machine-dependent) OOM stack trace
+-- does not leak into the portable expected output.
+CREATE FUNCTION alloc_mb(mb int) RETURNS text LANGUAGE pljs AS $$
+  try { var a = new ArrayBuffer(mb * 1024 * 1024); return "ok:" + a.byteLength; }
+  catch (e) { return "oom:" + e.message; }
+$$;
+
+-- 200MB fits under the 300MB load-time cap.
+SELECT alloc_mb(200) AS at_300_cap;
+
+-- Lowering the cap at runtime must now bite: 200MB no longer fits under 64MB.
+-- (Before the fix the runtime stayed at 300MB and this returned "ok".)
+SET pljs.memory_limit = 64;
+SELECT alloc_mb(200) AS at_64_cap;
+
+-- Raising the cap at runtime lets the same allocation succeed again.
+SET pljs.memory_limit = 512;
+SELECT alloc_mb(200) AS at_512_cap;
+
+RESET pljs.memory_limit;
+DROP FUNCTION alloc_mb(int);

--- a/sql/pg_name_bind.sql
+++ b/sql/pg_name_bind.sql
@@ -1,0 +1,44 @@
+-- A JavaScript string bound to a `name` column must be laid out as a name.
+--
+-- NAMEOID was handled together with text, varchar and bpchar, all of which build
+-- a varlena. `name` is not a varlena: it is a fixed-length NameData of
+-- NAMEDATALEN bytes with no length word. Building it as text puts a varlena
+-- header into the first bytes of the value, and anything comparing it against a
+-- real name reads that header as characters.
+--
+-- Nothing raises. The value simply never matches, so every system-catalog lookup
+-- driven by a JavaScript string returns no rows -- which is how most catalog
+-- introspection is written.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- The case that matters: look a catalog object up by name.
+CREATE FUNCTION nb_schema_rows(n text) RETURNS int AS $$
+  return pljs.execute('SELECT nspname FROM pg_namespace WHERE nspname = $1', [n]).length;
+$$ LANGUAGE pljs;
+
+SELECT nb_schema_rows('pg_catalog') AS schema_found;
+
+CREATE FUNCTION nb_type_count(n text) RETURNS int AS $$
+  return pljs.execute('SELECT count(*)::int AS c FROM pg_type WHERE typname = $1', [n])[0].c;
+$$ LANGUAGE pljs;
+
+SELECT nb_type_count('int4') AS int4_found;
+
+-- And a plain round trip.
+CREATE FUNCTION nb_roundtrip(n text) RETURNS text AS $$
+  return pljs.execute('SELECT $1::name::text AS t', [n])[0].t;
+$$ LANGUAGE pljs;
+
+SELECT nb_roundtrip('hello_name') AS roundtrip;
+SELECT nb_roundtrip('') AS empty_name;
+
+-- namein() truncates at NAMEDATALEN - 1 rather than raising, so a long value is
+-- accepted and shortened. 70 characters in, 63 out.
+SELECT length(nb_roundtrip(repeat('x', 70))) AS truncated_length;
+
+-- Returning a name works through the same conversion.
+CREATE FUNCTION nb_return() RETURNS name AS $$ return 'returned_name'; $$ LANGUAGE pljs;
+
+SELECT nb_return() = 'returned_name'::name AS returned_matches;
+
+DROP FUNCTION nb_schema_rows, nb_type_count, nb_roundtrip, nb_return;

--- a/sql/pg_nested_stack_anchor.sql
+++ b/sql/pg_nested_stack_anchor.sql
@@ -1,0 +1,78 @@
+-- Nested JS -> SQL -> JS re-entry must be bounded by PostgreSQL, not by a QuickJS
+-- budget measured from the wrong place.
+--
+-- JS_NewRuntime() records the C-stack top once, inside _PG_init, at whatever depth
+-- the first pljs call happened to be at.  JS_SetMaxStackSize() then sizes the budget
+-- relative to that anchor.  But JS can run far deeper than the anchor
+-- (SQL -> JS -> pljs.execute -> SQL -> JS -> ...), and each level of that nesting
+-- consumes C stack the anchor knows nothing about -- so the guard fires while there
+-- is plenty of stack left, rejecting legitimate work.
+--
+-- Measured before the fix: nest(250) failed with QuickJS's "stack overflow" while
+-- nest(150) succeeded.  After it, nest(300) succeeds and deep nesting is stopped by
+-- PostgreSQL's own check_stack_depth() instead.
+--
+-- Note the direction, which is the counter-intuitive part: the guard trips *earlier*
+-- than it should, not later.  _PG_init is the shallowest point in the backend, so at
+-- any nested depth QuickJS believes it is nearer the end of the stack than it is.  That
+-- is what makes this a functional bug and not merely a weakened guard: correct work is
+-- refused.
+--
+-- The fix is JS_UpdateStackTop(), which the vendored QuickJS exports, called at each
+-- entry into JS so the budget is measured from where that call actually begins.
+--
+-- This test asserts the *kind* of limit rather than a specific depth, because the
+-- depth at which either limit is reached depends on per-frame C stack usage and so
+-- varies by platform and build flags.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+CREATE FUNCTION nest(n int) RETURNS int LANGUAGE pljs AS $$
+  if (n <= 0) { return 0; }
+  return 1 + pljs.execute("SELECT nest(" + (n - 1) + ") AS v")[0].v;
+$$;
+
+-- Shallow nesting, which worked before and after.
+SELECT nest(10) AS nest_10;
+
+-- Moderate nesting.  This is the depth that failed before the fix.
+SELECT nest(250) AS nest_250;
+
+-- Whatever finally stops unbounded nesting must be PostgreSQL's check_stack_depth,
+-- not QuickJS deciding it is out of stack.  Reported as a classification so the
+-- output does not depend on which exact depth trips it.
+CREATE FUNCTION nest_limit_kind() RETURNS text LANGUAGE plpgsql AS $$
+DECLARE d int := 100;
+BEGIN
+  WHILE d <= 100000 LOOP
+    BEGIN
+      PERFORM nest(d);
+    EXCEPTION WHEN OTHERS THEN
+      IF SQLERRM LIKE '%stack depth limit exceeded%' THEN
+        RETURN 'bounded by PostgreSQL check_stack_depth';
+      ELSIF SQLERRM LIKE '%stack overflow%' THEN
+        RETURN 'bounded by QuickJS stack overflow (anchor is wrong)';
+      ELSE
+        RETURN 'unexpected: ' || SQLERRM;
+      END IF;
+    END;
+    d := d * 2;
+  END LOOP;
+  RETURN 'no limit reached by depth 100000';
+END $$;
+SELECT nest_limit_kind() AS what_bounds_nesting;
+
+-- And the backend is still usable afterwards.
+SELECT 'backend alive' AS status;
+
+-- Pure-JS recursion is still QuickJS's business, and must raise catchably rather
+-- than crash the backend.
+CREATE FUNCTION purejs_recursion() RETURNS int LANGUAGE pljs AS $$
+  function r(n) { return n <= 0 ? 0 : 1 + r(n - 1); }
+  try { r(10000000); return 0; } catch (e) { return 1; }
+$$;
+SELECT purejs_recursion() AS pure_js_recursion_caught;
+SELECT 'backend alive' AS status2;
+
+DROP FUNCTION purejs_recursion();
+DROP FUNCTION nest_limit_kind();
+DROP FUNCTION nest(int);

--- a/sql/pg_number_string_parse.sql
+++ b/sql/pg_number_string_parse.sql
@@ -1,0 +1,70 @@
+-- A JavaScript string bound to an integer or numeric column is parsed by that
+-- type's input function, not coerced through a double.
+--
+-- QuickJS's numeric coercion (JS_ToInt32/JS_ToInt64/JS_ToFloat64) routes the text
+-- through an IEEE-754 double, which holds 53 bits of mantissa. Anything wider is
+-- rounded before PostgreSQL ever sees it, and the failure is silent: the value is
+-- not rejected, it is quietly a different number. WAL LSNs are uint64 and a row
+-- id passes 2^53 long before it reaches INT64_MAX, so this is reachable with
+-- ordinary data.
+--
+-- plv8 parses such a bind with the type's input function, so this also makes the
+-- two engines agree.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- int8 at the limits, exactly.
+CREATE FUNCTION nsp_int8(s text) RETURNS int8 AS $$
+  return pljs.execute('SELECT $1::int8 AS v', [s])[0].v;
+$$ LANGUAGE pljs;
+
+SELECT nsp_int8('9223372036854775807') = 9223372036854775807::int8 AS int64_max_exact;
+SELECT nsp_int8('-9223372036854775808') = (-9223372036854775808)::int8 AS int64_min_exact;
+
+-- Above 2^53 but nowhere near the limit: the case that looks harmless.
+SELECT nsp_int8('123456789012345678') = 123456789012345678::int8 AS past_2_53_exact;
+SELECT nsp_int8('9007199254740993') = 9007199254740993::int8 AS just_past_2_53_exact;
+
+-- Out of range raises instead of wrapping.
+\set VERBOSITY terse
+SELECT nsp_int8('9223372036854775808');
+\set VERBOSITY default
+
+-- int4 and int2 take the same path.
+CREATE FUNCTION nsp_int4(s text) RETURNS int4 AS $$
+  return pljs.execute('SELECT $1::int4 AS v', [s])[0].v;
+$$ LANGUAGE pljs;
+
+SELECT nsp_int4('2147483647') AS int4_max;
+\set VERBOSITY terse
+SELECT nsp_int4('2147483648');
+SELECT nsp_int4('abc');
+\set VERBOSITY default
+
+-- numeric keeps a scale no double can represent.
+CREATE FUNCTION nsp_numeric(s text) RETURNS numeric AS $$
+  return pljs.execute('SELECT $1::numeric AS v', [s])[0].v;
+$$ LANGUAGE pljs;
+
+SELECT nsp_numeric('12345678901234567890.123456789') AS numeric_exact;
+
+-- The non-string paths are unchanged: a BigInt is still marshalled directly, and
+-- an ordinary Number still works where it is exact.
+CREATE FUNCTION nsp_bigint() RETURNS int8 AS $$
+  return pljs.execute('SELECT $1::int8 AS v', [9223372036854775807n])[0].v;
+$$ LANGUAGE pljs;
+
+SELECT nsp_bigint() = 9223372036854775807::int8 AS bigint_still_exact;
+
+CREATE FUNCTION nsp_number() RETURNS int4 AS $$
+  return pljs.execute('SELECT $1::int4 AS v', [42])[0].v;
+$$ LANGUAGE pljs;
+
+SELECT nsp_number() AS number_unchanged;
+
+-- A returned value takes the same conversion, so a string returned for an int8
+-- column is exact too.
+CREATE FUNCTION nsp_return_string() RETURNS int8 AS $$ return '9223372036854775807'; $$ LANGUAGE pljs;
+
+SELECT nsp_return_string() = 9223372036854775807::int8 AS returned_string_exact;
+
+DROP FUNCTION nsp_int8, nsp_int4, nsp_numeric, nsp_bigint, nsp_number, nsp_return_string;

--- a/sql/pg_object_keys_leak.sql
+++ b/sql/pg_object_keys_leak.sql
@@ -1,0 +1,49 @@
+-- Regression: enumerating a JS object's keys must free the property table and
+-- the atom references that JS_GetOwnPropertyNames() hands back.
+--
+-- Two hot paths enumerate object keys and previously freed neither the
+-- js_malloc'd JSPropertyEnum table nor the per-property atom references:
+--   * jsonb_object_from_object()                 -- every JS object -> jsonb
+--     conversion, i.e. any function returning jsonb of an object;
+--   * pljs_jsvalue_object_contains_all_column_names() -- every composite /
+--     SETOF return_next() row.
+-- The leaked table counts against the QuickJS runtime memory limit and is never
+-- reclaimed until the backend exits, so a long-running backend slowly exhausts
+-- pljs.memory_limit and then fails every JS call with "out of memory".
+--
+-- Under a tight cap (64MB, the minimum) the loops below leaked ~128MB and OOM'd
+-- before the fix (~ one table per conversion / per row, sized by the object's
+-- key count); they must now complete.  Objects are deliberately given many keys
+-- so the pre-fix leak dwarfs the cap with a wide, platform-independent margin
+-- while the iteration counts stay small and fast.
+CREATE EXTENSION IF NOT EXISTS pljs;
+SET pljs.memory_limit = 64;
+
+-- 1) JS object -> jsonb (jsonb_object_from_object), reached via return_next of a
+-- SETOF jsonb.  The fat object is built once and converted per row, so this is
+-- cheap to run but leaks one table per conversion.  20k rows of an ~800-key
+-- object is ~128MB of leaked tables vs the 64MB cap -> OOM pre-fix.
+CREATE FUNCTION jsonb_obj_leak(n int) RETURNS SETOF jsonb LANGUAGE pljs AS $$
+  var o = {};
+  for (var k = 0; k < 800; k++) o["c" + k] = k;
+  for (var i = 0; i < n; i++) pljs.return_next(o);
+$$;
+SELECT count(*) = 20000 AS jsonb_object_return_ok FROM jsonb_obj_leak(20000);
+
+-- 2) composite return_next (contains_all_column_names): the enumerated table is
+-- sized by *all* of the object's own keys, not just the target columns, so a
+-- one-column result fed a fat object leaks a big table per row.  20k rows of a
+-- ~800-key object is ~128MB of leaked tables vs the 64MB cap -> OOM pre-fix.
+CREATE FUNCTION composite_obj_leak(n int) RETURNS TABLE(a int) LANGUAGE pljs AS $$
+  var o = {a: 0};
+  for (var k = 0; k < 800; k++) o["x" + k] = k;
+  for (var i = 0; i < n; i++) { o.a = i; pljs.return_next(o); }
+$$;
+SELECT count(*) = 20000 AS composite_return_next_ok FROM composite_obj_leak(20000);
+
+-- The backend survived both loops and is still usable.
+SELECT 1 AS alive;
+
+RESET pljs.memory_limit;
+DROP FUNCTION jsonb_obj_leak(int);
+DROP FUNCTION composite_obj_leak(int);

--- a/sql/pg_param_plan_error_leak.sql
+++ b/sql/pg_param_plan_error_leak.sql
@@ -1,0 +1,63 @@
+-- Regression: pljs.execute() with parameters leaked its SPI plan whenever the
+-- query raised.
+--
+-- pljs_execute_params() freed the plan, the parameter list and the parameter
+-- arrays *after* SPI_execute_plan_with_paramlist().  Any query that raised --
+-- the common case in real code, and the entire point of a retry loop -- skipped
+-- all of it.  Nothing else reclaims it: the unsaved plan lives in the SPI
+-- procedure context and the rest in the caller's, and neither is reset by the
+-- subtransaction rollback that pljs.execute() performs to make the error
+-- catchable in JavaScript.
+--
+-- So a loop that retries a failing parameterised statement grew at the same rate
+-- as the successful-loop case this was originally reported for.
+--
+-- Threshold rationale, so the number is not simply raised until it tests nothing: measured on PostgreSQL 17, the leak costs about
+-- 1.6 kB per failed iteration, reaching ~3.1 MB at 2000 iterations.  With the
+-- plan freed on the error path it is about 0.55 kB per iteration, ~1.1 MB.  The
+-- 2 MB bound below sits between the two, so this test fails without the fix and
+-- passes with it rather than merely tracking whatever the current number is.
+--
+-- The residual ~0.55 kB per iteration is SPI's own per-statement bookkeeping and
+-- the subtransaction machinery, which is pre-existing and not what this fixes.
+CREATE FUNCTION planleak_spi_bytes(n int) RETURNS bigint AS $$
+  for (let i = 0; i < n; i++) {
+    // Prepares a plan through SPI_prepare_params, then fails in the execute.
+    try { pljs.execute('SELECT $1::int / 0', [i]); } catch (e) { /* expected */ }
+  }
+  const r = pljs.execute(
+    "SELECT coalesce(sum(total_bytes), 0)::bigint AS b " +
+    "FROM pg_backend_memory_contexts WHERE name LIKE 'SPI%'");
+  return BigInt(r[0].b);
+$$ LANGUAGE pljs;
+
+SELECT planleak_spi_bytes(2000) < 2 * 1024 * 1024 AS spi_growth_bounded;
+
+-- The successful path must stay bounded too -- that is what the fix originally
+-- covered, and this pins it so a refactor cannot regress it.
+CREATE FUNCTION planleak_ok_spi_bytes(n int) RETURNS bigint AS $$
+  for (let i = 0; i < n; i++) {
+    pljs.execute('SELECT $1::int AS v', [i]);
+  }
+  const r = pljs.execute(
+    "SELECT coalesce(sum(total_bytes), 0)::bigint AS b " +
+    "FROM pg_backend_memory_contexts WHERE name LIKE 'SPI%'");
+  return BigInt(r[0].b);
+$$ LANGUAGE pljs;
+
+SELECT planleak_ok_spi_bytes(2000) < 2 * 1024 * 1024 AS spi_growth_bounded_on_success;
+
+-- A mix: the two paths must not interact, and the function must still work
+-- correctly after thousands of caught failures.
+CREATE FUNCTION planleak_mixed(n int) RETURNS int AS $$
+  let ok = 0;
+  for (let i = 0; i < n; i++) {
+    try { pljs.execute('SELECT $1::int / 0', [i]); } catch (e) { /* expected */ }
+    ok += pljs.execute('SELECT $1::int AS v', [i])[0].v === i ? 1 : 0;
+  }
+  return ok;
+$$ LANGUAGE pljs;
+
+SELECT planleak_mixed(500) AS correct_after_interleaved_failures;
+
+DROP FUNCTION planleak_spi_bytes, planleak_ok_spi_bytes, planleak_mixed;

--- a/sql/pg_param_plan_leak.sql
+++ b/sql/pg_param_plan_leak.sql
@@ -1,0 +1,60 @@
+-- Regression: a single pljs function that loops over a large batch must not grow
+-- the SPI procedure context by a whole plan / ParamListInfo per iteration.
+--
+-- pljs_execute_params() prepared an *unsaved* SPI plan (and pljs_variable_param_
+-- setup pallocated param_types) on every parameterised pljs.execute(), and the
+-- plan.execute() path built a ParamListInfo per call -- all in the SPI proc
+-- context, which is only released when the enclosing function returns.  A mirror
+-- procedure applying a large change batch in one call therefore grew by
+-- kilobytes (a full cached plan) per row: ~100MB over 20k parameterised
+-- executes.  The fix frees the plan, param_types and ParamListInfo after each
+-- SPI call.
+--
+-- Growth is measured inside a single call from pg_backend_memory_contexts, so it
+-- captures exactly the within-call accumulation that the fix targets. Thresholds
+-- are loose enough to be platform-stable but far below the pre-fix growth (a real
+-- regression grows proportionally to the iteration count).
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- Parameterised one-shot execute in a tight loop (the pljs_execute_params path).
+-- Pre-fix this grew ~100MB over 20000 iterations; post-fix it is a few MB at
+-- most (the residual is transient high-water reclaimed at return).
+CREATE FUNCTION exec_param_growth_mb(n int) RETURNS float8 LANGUAGE pljs AS $$
+  var q = "SELECT sum(total_bytes)::float8 AS b FROM pg_backend_memory_contexts";
+  var before = pljs.execute(q)[0].b;
+  for (var i = 0; i < n; i++) {
+    pljs.execute("SELECT $1::int AS v", [i & 255]);
+  }
+  pljs.gc();
+  return (pljs.execute(q)[0].b - before) / (1024 * 1024);
+$$;
+SELECT exec_param_growth_mb(20000) < 15 AS param_execute_bounded;
+
+-- Prepared plan.execute() reuse in a tight loop (the plan.execute path).
+-- Pre-fix this grew ~1 ParamListInfo per call (~8MB over 40000); post-fix ~0.
+CREATE FUNCTION plan_exec_growth_mb(n int) RETURNS float8 LANGUAGE pljs AS $$
+  var q = "SELECT sum(total_bytes)::float8 AS b FROM pg_backend_memory_contexts";
+  var plan = pljs.prepare("SELECT $1::int AS v", ["int4"]);
+  var before = pljs.execute(q)[0].b;
+  for (var i = 0; i < n; i++) {
+    plan.execute([i & 255]);
+  }
+  plan.free();
+  pljs.gc();
+  return (pljs.execute(q)[0].b - before) / (1024 * 1024);
+$$;
+SELECT plan_exec_growth_mb(40000) < 5 AS plan_execute_bounded;
+
+-- The results are still correct after all that freeing (no use-after-free).
+CREATE FUNCTION param_still_correct() RETURNS boolean LANGUAGE pljs AS $$
+  var plan = pljs.prepare("SELECT $1::int + $2::int AS s", ["int4", "int4"]);
+  var a = pljs.execute("SELECT $1::int AS v", [41])[0].v;
+  var b = plan.execute([40, 2])[0].s;
+  plan.free();
+  return a === 41 && b === 42;
+$$;
+SELECT param_still_correct() AS results_correct;
+
+DROP FUNCTION exec_param_growth_mb(int);
+DROP FUNCTION plan_exec_growth_mb(int);
+DROP FUNCTION param_still_correct();

--- a/sql/pg_plan_argcount_sqlstate.sql
+++ b/sql/pg_plan_argcount_sqlstate.sql
@@ -1,0 +1,40 @@
+-- The argument-count mismatch on a prepared plan is the caller's mistake -- the
+-- wrong number of values was passed -- so it must carry a SQLSTATE that says so.
+-- It was raised with elog(), which means ERRCODE_INTERNAL_ERROR (XX000), and XX000
+-- tells the caller to treat the failure as a bug in the extension rather than as
+-- its own error.
+--
+-- Asserted with \set VERBOSITY sqlstate, which prints the code and nothing else.
+-- It cannot be read from JavaScript: this error is raised by a C function that
+-- QuickJS called, and it unwinds past any JavaScript try/catch rather than
+-- arriving as an exception -- unlike an error from pljs.execute().
+CREATE FUNCTION pac_execute() RETURNS int AS $$
+  const plan = pljs.prepare('SELECT $1::int AS v', ['int']);
+  return plan.execute([])[0].v;
+$$ LANGUAGE pljs;
+
+CREATE FUNCTION pac_too_many() RETURNS int AS $$
+  const plan = pljs.prepare('SELECT $1::int AS v', ['int']);
+  return plan.execute([1, 2])[0].v;
+$$ LANGUAGE pljs;
+
+-- The cursor entry point carries its own copy of the same check.
+CREATE FUNCTION pac_cursor() RETURNS int AS $$
+  const plan = pljs.prepare('SELECT $1::int AS v', ['int']);
+  const c = plan.cursor([]);
+  c.close();
+  return 1;
+$$ LANGUAGE pljs;
+
+\set VERBOSITY sqlstate
+SELECT pac_execute();
+SELECT pac_too_many();
+SELECT pac_cursor();
+\set VERBOSITY default
+
+-- And the message itself still says what happened.
+\set VERBOSITY terse
+SELECT pac_execute();
+\set VERBOSITY default
+
+DROP FUNCTION pac_execute, pac_too_many, pac_cursor;

--- a/sql/pg_prepared_plan_gc.sql
+++ b/sql/pg_prepared_plan_gc.sql
@@ -1,0 +1,50 @@
+-- Regression: a prepared statement that JavaScript never .free()'s used to
+-- leak its saved SPI plan plus CacheMemoryContext parstate for the life of the
+-- backend.  Preparing 20k plans in a loop grew CacheMemoryContext by ~64MB
+-- with no way to reclaim it -- exactly the kind of slow leak a long-running
+-- worker hits.  The prepared-statement handle class now has a GC finalizer, so
+-- once the handle becomes unreachable the plan is reclaimed and growth stays
+-- bounded by the GC interval.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- Prepare many plans without ever calling free(); after a GC the CacheMemory
+-- growth must stay far below the ~64MB the leak used to produce.  We compare in
+-- float8 so the arithmetic stays in JS Number space (mixing BigInt and Number
+-- throws a TypeError).
+CREATE FUNCTION prep_no_free(n int) RETURNS boolean LANGUAGE pljs AS $$
+  // Match the leak-bearing contexts by name rather than by parent:
+  // pg_backend_memory_contexts dropped the `parent` column in PostgreSQL 18
+  // (replaced by `type` and `path`), so a parent-based query does not even
+  // parse there.  An unfreed plan leaves behind a CachedPlanSource and an
+  // "SPI Plan" context apiece, so 20k of them is tens of MB -- while the fixed
+  // build stays around 5KB.
+  var q = "SELECT sum(total_bytes)::float8 AS b FROM pg_backend_memory_contexts" +
+          " WHERE name IN ('CacheMemoryContext', 'CachedPlanSource'," +
+          " 'CachedPlanQuery', 'SPI Plan')";
+  var before = pljs.execute(q)[0].b;
+  for (var i = 0; i < n; i++) {
+    var p = pljs.prepare("SELECT $1::int + " + i, ["int"]);
+    p.execute([i]);
+  }
+  pljs.gc();
+  var after = pljs.execute(q)[0].b;
+  return (after - before) < 10 * 1024 * 1024;
+$$;
+
+SELECT prep_no_free(20000) AS leak_bounded;
+
+-- Explicitly freeing a plan and then triggering GC must not double-free the
+-- underlying SPI plan (the free path clears the handle's opaque).
+CREATE FUNCTION free_then_gc() RETURNS int LANGUAGE pljs AS $$
+  var p = pljs.prepare("SELECT 1");
+  p.execute();
+  p.free();
+  pljs.gc();
+  return 1;
+$$;
+
+SELECT free_then_gc();
+SELECT 1 AS alive;
+
+DROP FUNCTION prep_no_free(int);
+DROP FUNCTION free_then_gc();

--- a/sql/pg_prepared_plan_lifetime.sql
+++ b/sql/pg_prepared_plan_lifetime.sql
@@ -1,0 +1,27 @@
+-- Regression test for prepared-plan / by-reference-return lifetime bugs tied to
+-- call_function()'s execution_context (which is deleted on return).
+--
+-- 1. pljs_prepare() allocated parstate and param_types in CurrentMemoryContext
+--    (= execution_context), so a prepared plan reused in a LATER call
+--    dereferenced freed memory (0x7F7F7F7F). The fix allocates the plan and
+--    parstate in CacheMemoryContext. Here a plan is cached on globalThis in the
+--    first call and reused across later calls; every call must return 7.
+-- 2. A by-reference return value (text, bytea, ...) was computed in
+--    execution_context just before that context was deleted, so the returned
+--    pointer was invalid. The fix switches back to the caller's context before
+--    building the return datum. A function returning a large string must come
+--    back intact.
+CREATE FUNCTION f_plan_reuse() RETURNS int LANGUAGE pljs AS $$
+  if (!globalThis.__plan_reuse)
+    globalThis.__plan_reuse = pljs.prepare('SELECT $1::int + $2::int AS s', ['int', 'int']);
+  return globalThis.__plan_reuse.execute([3, 4])[0].s;
+$$;
+SELECT f_plan_reuse() AS call1;
+SELECT f_plan_reuse() AS call2;
+SELECT f_plan_reuse() AS call3;
+
+CREATE FUNCTION f_byref_return() RETURNS text LANGUAGE pljs AS $$ return 'ab'.repeat(5000); $$;
+SELECT length(f_byref_return()) AS len, substr(f_byref_return(), 1, 4) AS head;
+
+DROP FUNCTION f_plan_reuse();
+DROP FUNCTION f_byref_return();

--- a/sql/pg_record_column_leak.sql
+++ b/sql/pg_record_column_leak.sql
@@ -1,0 +1,59 @@
+-- Regression: the composite/record column loop leaked one QuickJS reference per
+-- column, per row.
+--
+-- pljs_jsvalue_to_datums() and the column loop in pljs_jsvalue_to_record() both
+-- did:
+--
+--     JSValue o = JS_GetPropertyStr(ctx, val, colname);
+--     if (JS_IsNull(o) || JS_IsUndefined(o)) { nulls[c] = true; continue; }
+--     values[c] = pljs_jsvalue_to_datum(..., o, ..., NULL);
+--
+-- JS_GetPropertyStr() returns an *owned* reference and `o` was never released on
+-- either path.  That is one leaked reference per column per row, on every
+-- composite return and every return_next() of a row object -- the hottest
+-- allocation path in the extension.
+--
+-- This test asserts against pljs.memory_limit rather than
+-- pg_backend_memory_contexts, and that choice is the whole point: QuickJS
+-- allocates on the libc heap, so a leaked JavaScript reference is completely
+-- invisible to pg_backend_memory_contexts.  A test built on that view would pass
+-- whether or not the leak is fixed.
+--
+-- The retained object is deliberately large (4KB per call) so a bounded 64MB
+-- heap is exhausted in a few thousand calls: with the leak this fails with
+-- "InternalError: out of memory" well before 30000, and small values would not
+-- discriminate because QuickJS represents small integers as immediates that are
+-- not reference counted at all.
+CREATE TYPE colleak_row AS (big text);
+
+CREATE FUNCTION colleak_one(i int) RETURNS colleak_row AS $$
+  return { big: 'x'.repeat(4096) + i };
+$$ LANGUAGE pljs;
+
+-- 30000 calls x 4KB retained = ~120MB, comfortably past the cap below.
+SET pljs.memory_limit = 64;
+
+SELECT count(*) AS calls
+  FROM (SELECT (colleak_one(i)).* FROM generate_series(1, 30000) i) s;
+
+-- The same loop runs for return_next() of a row object.
+CREATE FUNCTION colleak_set(n int) RETURNS SETOF colleak_row AS $$
+  for (let i = 0; i < n; i++) pljs.return_next({ big: 'y'.repeat(4096) + i });
+$$ LANGUAGE pljs;
+
+SELECT count(*) AS rows_from_set FROM colleak_set(20000);
+
+-- A NULL column takes the short-circuit path, which leaked the same reference.
+CREATE TYPE colleak_two AS (a text, b text);
+
+CREATE FUNCTION colleak_nulls(i int) RETURNS colleak_two AS $$
+  return { a: null, b: 'z'.repeat(4096) + i };
+$$ LANGUAGE pljs;
+
+SELECT count(*) AS calls_with_null_column
+  FROM (SELECT (colleak_nulls(i)).* FROM generate_series(1, 20000) i) s;
+
+RESET pljs.memory_limit;
+
+DROP FUNCTION colleak_one, colleak_set, colleak_nulls;
+DROP TYPE colleak_row, colleak_two;

--- a/sql/pg_record_no_column_list.sql
+++ b/sql/pg_record_no_column_list.sql
@@ -1,0 +1,27 @@
+-- A `RETURNS record` function called without a column definition list produced
+-- "record type has not been registered", which is an unhelpful way to say
+-- "you forgot AS (a int, b text)".
+--
+-- call_function() discarded get_call_result_type()'s status.  TYPEFUNC_RECORD
+-- means the caller supplied no column list and hands back a NULL tupdesc;
+-- pljs_jsvalue_to_record() then reached lookup_rowtype_tupdesc(RECORDOID, -1),
+-- which is where that message comes from.
+CREATE FUNCTION recnl() RETURNS record AS $$
+  return { a: 1, b: 'x' };
+$$ LANGUAGE pljs;
+
+-- No column definition list: a clear error naming what is missing.
+SELECT recnl();
+
+-- With one, it works.
+SELECT * FROM recnl() AS x(a int, b text);
+
+-- The SETOF form has its own path and must stay working.
+CREATE FUNCTION recnl_set() RETURNS SETOF record AS $$
+  pljs.return_next({ a: 1, b: 'one' });
+  pljs.return_next({ a: 2, b: 'two' });
+$$ LANGUAGE pljs;
+
+SELECT * FROM recnl_set() AS x(a int, b text);
+
+DROP FUNCTION recnl, recnl_set;

--- a/sql/pg_return_next_error_frames.sql
+++ b/sql/pg_return_next_error_frames.sql
@@ -1,0 +1,61 @@
+-- Regression: a PostgreSQL error raised inside pljs.return_next() escaped past
+-- JavaScript instead of arriving as a catchable exception.
+--
+-- return_next is a C function that QuickJS called, so QuickJS has live
+-- JSStackFrame structures on the C stack between it and the interpreter, linked
+-- from the runtime.  An ereport(ERROR) there siglongjmps straight past them: any
+-- JavaScript try/catch around the call never runs, and the runtime is left with
+-- rt->current_stack_frame pointing at frames that no longer exist.
+--
+-- pljs.execute() has always converted PostgreSQL errors into JavaScript
+-- exceptions for exactly this reason.  return_next now does the same.
+--
+-- The error used below is the one an array-typed column raises when the property
+-- it is given is not an array: an ordinary ereport from inside the conversion,
+-- which needs no other change to reach.
+CREATE TYPE rnx_row AS (a int[]);
+
+CREATE FUNCTION rnx_bad_srf() RETURNS SETOF rnx_row AS $$
+  pljs.return_next({ a: 'not-an-array' });
+$$ LANGUAGE pljs;
+
+-- Still reported to the caller.
+SELECT count(*) FROM rnx_bad_srf();
+
+-- And now catchable in JavaScript, which is the part that changed: without the
+-- guard the longjmp skips this catch entirely and the error surfaces in SQL.
+CREATE FUNCTION rnx_caught() RETURNS SETOF rnx_row AS $$
+  try {
+    pljs.return_next({ a: 'not-an-array' });
+  } catch (e) {
+    pljs.elog(NOTICE, 'caught in JavaScript: ' + e.message);
+  }
+$$ LANGUAGE pljs;
+
+SELECT count(*) FROM rnx_caught();
+
+-- Rows emitted before the failure survive it, and the set still ends cleanly.
+CREATE FUNCTION rnx_partial() RETURNS SETOF rnx_row AS $$
+  pljs.return_next({ a: [1, 2] });
+  try {
+    pljs.return_next({ a: 'not-an-array' });
+  } catch (e) {
+    pljs.elog(NOTICE, 'second row rejected: ' + e.message);
+  }
+  pljs.return_next({ a: [3] });
+$$ LANGUAGE pljs;
+
+SELECT * FROM rnx_partial();
+
+-- Constructing an Error afterwards walks the runtime's frame list, so it is the
+-- operation that would fault on a list left dangling by the longjmp.
+CREATE FUNCTION rnx_after() RETURNS text AS $$
+  try { throw new Error('after'); } catch (e) { return 'frame list intact: ' + e.message; }
+$$ LANGUAGE pljs;
+
+SELECT rnx_after();
+
+SELECT 1 AS alive;
+
+DROP FUNCTION rnx_bad_srf, rnx_caught, rnx_partial, rnx_after;
+DROP TYPE rnx_row;

--- a/sql/pg_return_next_null_row.sql
+++ b/sql/pg_return_next_null_row.sql
@@ -1,0 +1,59 @@
+-- return_next(null) emits a NULL row for a composite-returning set.
+--
+-- A composite set raised "argument must be an object" for null and undefined, so
+-- there was no way to emit a NULL row at all.  plpgsql expresses exactly that
+-- with RETURN NEXT NULL, and a caller mapping a nullable source row had to skip
+-- the row or invent a sentinel value instead.
+--
+-- null and undefined now produce an all-NULL row, consistent with the rest of
+-- the conversion surface, where both mean SQL NULL everywhere.  A non-null value
+-- of the wrong shape still raises.
+CREATE EXTENSION IF NOT EXISTS pljs;
+CREATE TYPE rnn_ct AS (a int, b text);
+
+-- 1) SETOF composite: null and undefined are NULL rows, interleaved with real
+-- rows in the right order.
+CREATE FUNCTION rnn_setof() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  pljs.return_next(null);
+  pljs.return_next({a: 1, b: 'x'});
+  pljs.return_next(undefined);
+$$;
+SELECT coalesce(a::text, 'NULL') AS a, coalesce(b, 'NULL') AS b FROM rnn_setof();
+
+-- the emitted rows really are NULL rows, not rows of NULL columns by accident.
+SELECT count(*) AS null_rows FROM rnn_setof() t WHERE t IS NULL;
+SELECT count(*) AS total_rows FROM rnn_setof();
+
+-- 2) RETURNS TABLE behaves the same.
+CREATE FUNCTION rnn_table() RETURNS TABLE(a int, b text) LANGUAGE pljs AS $$
+  pljs.return_next(null);
+  pljs.return_next({a: 2, b: 'y'});
+$$;
+SELECT coalesce(a::text, 'NULL') AS a, coalesce(b, 'NULL') AS b FROM rnn_table();
+
+-- 3) a wider row type is NULL in every column.
+CREATE FUNCTION rnn_wide() RETURNS TABLE(a int, b text, c bigint, d jsonb) LANGUAGE pljs AS $$
+  pljs.return_next(null);
+$$;
+SELECT a IS NULL AND b IS NULL AND c IS NULL AND d IS NULL AS all_null
+  FROM rnn_wide();
+
+-- 4) a non-null value of the wrong shape must still raise.
+CREATE FUNCTION rnn_bad_num() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  pljs.return_next(5);
+$$;
+CREATE FUNCTION rnn_bad_str() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  pljs.return_next('nope');
+$$;
+SELECT * FROM rnn_bad_num();
+SELECT * FROM rnn_bad_str();
+
+-- 5) a set of only NULL rows is still a set of rows, not an empty result.
+CREATE FUNCTION rnn_only_nulls() RETURNS SETOF rnn_ct LANGUAGE pljs AS $$
+  for (var i = 0; i < 3; i++) { pljs.return_next(null); }
+$$;
+SELECT count(*) AS rows FROM rnn_only_nulls();
+
+DROP FUNCTION rnn_setof, rnn_table, rnn_wide, rnn_bad_num, rnn_bad_str,
+  rnn_only_nulls;
+DROP TYPE rnn_ct;

--- a/sql/pg_spi_freetuptable.sql
+++ b/sql/pg_spi_freetuptable.sql
@@ -1,0 +1,56 @@
+-- Regression: pljs.execute() never freed its SPI tuptable.
+--
+-- pljs_plan_execute() called SPI_freetuptable() once it had converted its results.
+-- pljs_execute(), which backs pljs.execute(), did not -- so every call that
+-- returned rows kept the whole result set alive in the SPI context for as long as
+-- the surrounding function ran.  A loop inside one function accumulated all of it.
+--
+-- The measurement has to happen from inside the call: SPI_finish() releases the
+-- context when the function returns, so the leak is invisible from the outside
+-- either way.  pg_backend_memory_contexts is the right instrument here, unlike for
+-- a QuickJS-heap leak, because an SPI tuptable is PostgreSQL memory.
+--
+-- The assertion is a ratio rather than a byte count, so it does not depend on
+-- allocator details or platform: 1000 further executes must not add more than the
+-- first 100 already accounted for.  Unfixed, the second loop added ~32MB against
+-- ~3MB for the first; fixed, it adds nothing at all.
+CREATE FUNCTION spitup_growth() RETURNS bool AS $$
+  function spi_bytes() {
+    return pljs.execute("SELECT COALESCE(sum(total_bytes), 0)::float8 AS b " +
+                        "FROM pg_backend_memory_contexts WHERE name LIKE 'SPI%'")[0].b;
+  }
+
+  for (let i = 0; i < 100; i++) {
+    pljs.execute('SELECT g FROM generate_series(1, 200) g');
+  }
+  const before = spi_bytes();
+
+  for (let i = 0; i < 1000; i++) {
+    pljs.execute('SELECT g FROM generate_series(1, 200) g');
+  }
+  const after = spi_bytes();
+
+  return (after - before) < before;
+$$ LANGUAGE pljs;
+
+SELECT spitup_growth() AS spi_memory_bounded;
+
+-- Result-returning executes interleaved with commits, which is the pattern that
+-- made the retention easiest to hit in practice.
+CREATE TABLE t_freetup (a int);
+
+CREATE PROCEDURE p_freetup() LANGUAGE pljs AS $$
+  for (let i = 0; i < 20; i++) {
+    const rows = pljs.execute('SELECT g FROM generate_series(1, 50) g');
+    pljs.execute('INSERT INTO t_freetup (a) VALUES ($1)', [rows.length]);
+    pljs.commit();
+  }
+$$;
+
+CALL p_freetup();
+
+SELECT count(*)::int AS n, min(a) AS mn, max(a) AS mx FROM t_freetup;
+
+DROP PROCEDURE p_freetup;
+DROP TABLE t_freetup;
+DROP FUNCTION spitup_growth();

--- a/sql/pg_stack_depth.sql
+++ b/sql/pg_stack_depth.sql
@@ -1,0 +1,105 @@
+-- NB: some expected output below is QuickJS's own wording ("out of memory",
+-- "stack overflow"), which is not part of any stable interface -- it is pinned
+-- by the vendored deps/quickjs revision and will churn if that is bumped.  If a
+-- QuickJS upgrade fails here, check the message text before assuming a
+-- behaviour regression.
+-- Regression: deep / unbounded JS recursion must raise a catchable
+-- "stack overflow" error and leave the backend alive -- never crash it with a
+-- C-stack SIGSEGV.
+--
+-- QuickJS only performs stack checks when built with CONFIG_STACK_CHECK, and
+-- even then pljs previously relied on the vendored JS_DEFAULT_STACK_SIZE and
+-- never set a limit explicitly.  pljs now sets an explicit QuickJS stack budget
+-- (half of max_stack_depth, floored) in _PG_init, so pure-JS recursion trips
+-- QuickJS's guard well before PostgreSQL's own C-stack limit and the kernel
+-- stack limit are reached.
+--
+-- The derived bound is observable, and the section at the end of this file checks it.
+--
+-- It reads as though it could not be: the budget is derived once in _PG_init, so a
+-- later SET cannot change it.  But _PG_init runs when the library is first loaded in
+-- a given backend, which is the first pljs call in that session -- so a SET issued
+-- before any pljs function is called is exactly what it reads.  \c gives a fresh
+-- backend per setting, which is how the section below compares two of them.
+--
+-- Measured on PostgreSQL 17, the achievable pure-JS recursion depth tracks the
+-- derived budget almost exactly linearly:
+--
+--     max_stack_depth   derived JS budget   depth reached
+--     512kB             256kB (the floor)   268
+--     1024kB            512kB               537
+--     2048kB (default)  1024kB              1074
+--     4096kB            2048kB              2148
+--
+-- At the 2048kB default the derived budget is 1MB, which is what
+-- JS_DEFAULT_STACK_SIZE already is, so at default settings alone this file would
+-- pass with or without the explicit JS_SetMaxStackSize() call.  That is exactly why
+-- the comparison below uses two different settings.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- Unbounded self-recursion in an anonymous block.  Use terse verbosity: the
+-- InternalError stack trace carried in DETAIL is machine dependent (its length
+-- depends on frame size), so it must not appear in the portable expected file.
+\set VERBOSITY terse
+DO $$ function r(n) { return r(n + 1); } r(0); $$ LANGUAGE pljs;
+\set VERBOSITY default
+
+-- The backend survived the overflow and is still usable.
+SELECT 1 AS alive;
+
+-- The overflow surfaces as an ordinary, catchable JS error.
+CREATE FUNCTION deep_recurse() RETURNS text LANGUAGE pljs AS $$
+  function r(n) { return r(n + 1); }
+  try { r(0); }
+  catch (e) { return "caught: " + e.name + ": " + e.message; }
+  return "no error";
+$$;
+SELECT deep_recurse();
+
+-- Mutual JS<->SQL recursion is bounded as well: PostgreSQL's check_stack_depth
+-- stops it and the error is caught and unwound at every level, so the top-level
+-- call returns cleanly and the backend stays alive.
+CREATE FUNCTION mutual() RETURNS text LANGUAGE pljs AS $$
+  try { return pljs.execute("SELECT mutual()")[0].mutual; }
+  catch (e) { return "depth-limited"; }
+$$;
+SELECT mutual();
+SELECT 1 AS alive_after_mutual;
+
+DROP FUNCTION mutual();
+DROP FUNCTION deep_recurse();
+
+-- ---------------------------------------------------------------------------
+-- The derived budget is observable: a lower max_stack_depth must yield a
+-- proportionally lower achievable JS recursion depth.
+--
+-- Absolute depths depend on per-frame stack usage and so vary by platform and build
+-- flags; the assertion is the ratio, which is a property of the derivation.
+-- ---------------------------------------------------------------------------
+CREATE TABLE sd_depths (label text, d int);
+
+CREATE FUNCTION sd_probe() RETURNS int LANGUAGE pljs AS $$
+  let d = 0;
+  function r() { d++; r(); }
+  try { r(); } catch (e) { /* QuickJS stack guard */ }
+  return d;
+$$;
+
+-- Fresh backend, so _PG_init has not run yet and the SET below is what it reads.
+\c
+SET max_stack_depth = 512;
+INSERT INTO sd_depths SELECT 'low', sd_probe();
+
+\c
+SET max_stack_depth = 4096;
+INSERT INTO sd_depths SELECT 'high', sd_probe();
+
+-- 512kB floors the budget at 256kB, 4096kB gives 2048kB: an 8x budget, so the depth
+-- should be several times larger.  Asserted loosely (>3x) so that a platform with
+-- different frame sizes still passes while a build that ignores max_stack_depth
+-- entirely -- where both depths would be identical -- fails.
+SELECT (SELECT d FROM sd_depths WHERE label = 'high')
+       > 3 * (SELECT d FROM sd_depths WHERE label = 'low') AS budget_tracks_max_stack_depth;
+
+DROP FUNCTION sd_probe();
+DROP TABLE sd_depths;

--- a/sql/pg_targeted_invalidation.sql
+++ b/sql/pg_targeted_invalidation.sql
@@ -1,0 +1,33 @@
+-- Creating or replacing one function must not throw away every user's compiled
+-- state.  The previous behaviour was a full pljs_cache_reset(), which destroys the
+-- per-user JSContext -- and JS_FreeContext() will not free a context that still
+-- has live references, so a backend doing repeated DDL grew without bound.
+--
+-- Whether the context survived is observable from JavaScript: anything held on
+-- globalThis lives in that context, so it is still there after unrelated DDL
+-- exactly when the context was not destroyed.
+CREATE FUNCTION tin_set() RETURNS void AS $$
+  globalThis.tin_marker = 'kept';
+$$ LANGUAGE pljs;
+
+CREATE FUNCTION tin_get() RETURNS text AS $$
+  return globalThis.tin_marker || '(gone)';
+$$ LANGUAGE pljs;
+
+SELECT tin_set();
+SELECT tin_get() AS before_ddl;
+
+-- DDL on an unrelated function.
+CREATE FUNCTION tin_other() RETURNS int AS $$ return 1; $$ LANGUAGE pljs;
+
+SELECT tin_get() AS after_unrelated_create;
+
+CREATE OR REPLACE FUNCTION tin_other() RETURNS int AS $$ return 2; $$ LANGUAGE pljs;
+
+SELECT tin_get() AS after_unrelated_replace;
+
+-- The replaced function itself does pick up its new body, which is the whole point
+-- of invalidating anything at all.
+SELECT tin_other() AS new_body;
+
+DROP FUNCTION tin_set, tin_get, tin_other;

--- a/sql/pg_trigger_spi.sql
+++ b/sql/pg_trigger_spi.sql
@@ -1,0 +1,106 @@
+-- A trigger must be able to use SPI.
+--
+-- call_trigger() never called SPI_connect_ext(), which call_function() and
+-- call_srf_function() both do.  So every SPI entry point failed inside a trigger:
+-- not only DDL, but a bare pljs.execute("SELECT 1").  Upstream reports this as
+-- "execution error"; the error-surfacing work in this series turns it into the
+-- underlying "current transaction is aborted, commands ignored until end of
+-- transaction block", which is what made it findable at all.
+--
+-- Querying from a trigger is a primary use of a trigger, so this made a large part
+-- of the trigger surface unusable, and nothing in the suite covered it -- the
+-- existing trigger tests only inspect NEW/OLD and the TG_* variables.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+CREATE TABLE ts_log (msg text);
+CREATE TABLE ts_t (x int);
+
+-- A plain query, the case that failed most simply.
+CREATE FUNCTION ts_select() RETURNS trigger LANGUAGE pljs AS $$
+  const r = pljs.execute("SELECT 42 AS v");
+  if (r[0].v !== 42) { throw new Error("expected 42, got " + r[0].v); }
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr1 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_select();
+INSERT INTO ts_t VALUES (1);
+SELECT count(*)::int AS select_in_trigger FROM ts_t;
+DROP TRIGGER ts_tr1 ON ts_t;
+
+-- Writing to another table, which is the common audit-trigger shape.
+CREATE FUNCTION ts_insert() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("INSERT INTO ts_log VALUES ('row " + NEW.x + "')");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr2 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_insert();
+INSERT INTO ts_t VALUES (2), (3);
+SELECT msg FROM ts_log ORDER BY msg;
+DROP TRIGGER ts_tr2 ON ts_t;
+
+-- A prepared plan, with the explicit type array the API requires.
+CREATE FUNCTION ts_prepare() RETURNS trigger LANGUAGE pljs AS $$
+  const p = pljs.prepare('SELECT $1::int * 2 AS v', ['int4']);
+  const r = p.execute([NEW.x]);
+  p.free();
+  pljs.execute("INSERT INTO ts_log VALUES ('doubled " + r[0].v + "')");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr3 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_prepare();
+INSERT INTO ts_t VALUES (10);
+SELECT msg FROM ts_log WHERE msg LIKE 'doubled%';
+DROP TRIGGER ts_tr3 ON ts_t;
+
+-- A cursor, which goes through the plan/portal path rather than plain execute.
+CREATE FUNCTION ts_cursor() RETURNS trigger LANGUAGE pljs AS $$
+  const p = pljs.prepare('SELECT generate_series(1, 3) AS n');
+  const c = p.cursor();
+  let sum = 0, row;
+  while ((row = c.fetch())) { sum += row.n; }
+  c.close();
+  p.free();
+  if (sum !== 6) { throw new Error("expected 6, got " + sum); }
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr4 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_cursor();
+INSERT INTO ts_t VALUES (20);
+SELECT count(*)::int AS cursor_in_trigger FROM ts_t WHERE x = 20;
+DROP TRIGGER ts_tr4 ON ts_t;
+
+-- DDL from a trigger, including replacing the trigger function itself, which also
+-- exercises cache invalidation while the function is on the JS stack.
+CREATE FUNCTION ts_ddl() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("CREATE OR REPLACE FUNCTION ts_ddl() RETURNS trigger LANGUAGE pljs AS $b$ return NEW; $b$");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr5 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_ddl();
+INSERT INTO ts_t VALUES (30), (31);
+SELECT count(*)::int AS ddl_in_trigger FROM ts_t WHERE x IN (30, 31);
+DROP TRIGGER ts_tr5 ON ts_t;
+
+-- An error raised by SPI inside a trigger must still abort the statement cleanly
+-- and leave the session usable.
+CREATE FUNCTION ts_error() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("SELECT 1 FROM no_such_table_here");
+  return NEW;
+$$;
+CREATE TRIGGER ts_tr6 BEFORE INSERT ON ts_t FOR EACH ROW EXECUTE FUNCTION ts_error();
+\set VERBOSITY terse
+INSERT INTO ts_t VALUES (40);
+\set VERBOSITY default
+SELECT count(*)::int AS error_row_not_inserted FROM ts_t WHERE x = 40;
+DROP TRIGGER ts_tr6 ON ts_t;
+
+-- The session still works afterwards.
+SELECT 'session usable' AS after_error;
+
+-- A statement-level trigger reaches the same path.
+CREATE FUNCTION ts_stmt() RETURNS trigger LANGUAGE pljs AS $$
+  pljs.execute("INSERT INTO ts_log VALUES ('statement level')");
+  return null;
+$$;
+CREATE TRIGGER ts_tr7 AFTER INSERT ON ts_t EXECUTE FUNCTION ts_stmt();
+INSERT INTO ts_t VALUES (50);
+SELECT msg FROM ts_log WHERE msg = 'statement level';
+DROP TRIGGER ts_tr7 ON ts_t;
+
+DROP FUNCTION ts_stmt(), ts_error(), ts_ddl(), ts_cursor(), ts_prepare(), ts_insert(), ts_select();
+DROP TABLE ts_t, ts_log;

--- a/sql/pg_typedarray_views.sql
+++ b/sql/pg_typedarray_views.sql
@@ -1,0 +1,34 @@
+-- Typed-array -> bytea conversion, including 32-bit widths and offset views.
+--
+-- Regression test for a heap-buffer overflow in the Uint32Array / Int32Array
+-- -> bytea path in src/types.c: the copy loop iterated 4*length times while the
+-- destination held only length uint32 slots, overwriting 3*length slots past
+-- the end of the allocation. (The 8- and 16-bit paths already looped over
+-- length correctly.) The fix bounds the 32-bit loop by length. This pins the
+-- correct little-endian bytes for 8/16/32-bit views, an offset view
+-- (new Uint32Array(ab, byteOffset, n)), and that cursor.fetch still works when
+-- invoked through Function.prototype.apply.
+CREATE FUNCTION ta_u8()  RETURNS bytea LANGUAGE pljs AS $$ return new Uint8Array([1, 2, 3, 255]); $$;
+CREATE FUNCTION ta_u16() RETURNS bytea LANGUAGE pljs AS $$ return new Uint16Array([1, 258]); $$;
+CREATE FUNCTION ta_u32() RETURNS bytea LANGUAGE pljs AS $$ return new Uint32Array([1, 2, 3]); $$;
+CREATE FUNCTION ta_i32() RETURNS bytea LANGUAGE pljs AS $$ return new Int32Array([-1, 256]); $$;
+CREATE FUNCTION ta_off() RETURNS bytea LANGUAGE pljs AS $$
+  const ab = new ArrayBuffer(16);
+  const full = new Uint32Array(ab);
+  full[0] = 9; full[1] = 1; full[2] = 2; full[3] = 9;
+  return new Uint32Array(ab, 4, 2);   // view over elements 1,2 only
+$$;
+SELECT ta_u8() AS u8, ta_u16() AS u16, ta_u32() AS u32, ta_i32() AS i32, ta_off() AS off;
+
+DO $$
+  const cur = pljs.prepare('SELECT 42 AS x').cursor();
+  const row = cur.fetch.apply(cur);
+  pljs.elog(NOTICE, 'fetch.apply: ' + JSON.stringify(row));
+  cur.close();
+$$ LANGUAGE pljs;
+
+DROP FUNCTION ta_u8();
+DROP FUNCTION ta_u16();
+DROP FUNCTION ta_u32();
+DROP FUNCTION ta_i32();
+DROP FUNCTION ta_off();

--- a/sql/pg_validator.sql
+++ b/sql/pg_validator.sql
@@ -1,0 +1,87 @@
+-- The validator must validate the function being created, and must accept a pljs
+-- body rather than requiring a standalone program.
+--
+-- Two defects, which masked each other:
+--
+--   1. It read fcinfo->flinfo->fn_oid -- its *own* OID -- and so fetched the
+--      validator's pg_proc row, whose prosrc is the C symbol name
+--      "pljs_call_validator".  That parses as a bare JavaScript identifier, so
+--      validation always succeeded and any invalid body was accepted, with the
+--      syntax error surfacing only on the first call.
+--
+--   2. Correcting the OID alone is not enough: a pljs body is a function *body*,
+--      not a program, so `return 42;` is a syntax error at top level.  Validating
+--      the raw prosrc rejects almost every valid function -- measured at 46 of 89
+--      test files failing.  The body has to be wrapped the way compilation wraps
+--      it, which is why the source builder is now shared with
+--      pljs_compile_function().
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- A syntactically invalid body is rejected at CREATE time.
+\set VERBOSITY terse
+CREATE FUNCTION val_bad() RETURNS int LANGUAGE pljs AS $$ this is ( not js $$;
+
+-- An unterminated construct, likewise.
+CREATE FUNCTION val_unclosed() RETURNS int LANGUAGE pljs AS $$ if (true) { $$;
+\set VERBOSITY default
+
+-- Valid bodies are accepted, including the shapes that a naive "validate the raw
+-- prosrc" check would reject: a bare return, named arguments, and a trigger's
+-- implicit variables.
+CREATE FUNCTION val_return() RETURNS int LANGUAGE pljs AS $$ return 42; $$;
+CREATE FUNCTION val_args(a int, b text) RETURNS text LANGUAGE pljs AS $$
+  return b + a;
+$$;
+CREATE FUNCTION val_novoid() RETURNS void LANGUAGE pljs AS $$ pljs.elog(NOTICE, 'ok'); $$;
+
+SELECT val_return() AS returns_ok, val_args(1, 'x') AS args_ok;
+
+CREATE TABLE val_t (x int);
+CREATE FUNCTION val_trigger() RETURNS trigger LANGUAGE pljs AS $$
+  return NEW;
+$$;
+CREATE TRIGGER val_tr BEFORE INSERT ON val_t
+  FOR EACH ROW EXECUTE FUNCTION val_trigger();
+
+INSERT INTO val_t VALUES (1);
+SELECT count(*)::int AS trigger_inserted FROM val_t;
+
+-- check_function_bodies = off must skip validation entirely, which is what that
+-- setting is for (restoring a dump whose functions reference objects not yet
+-- created).
+SET check_function_bodies = off;
+CREATE FUNCTION val_deferred() RETURNS int LANGUAGE pljs AS $$ this is ( not js $$;
+RESET check_function_bodies;
+
+-- ... and the error then surfaces on first call instead.
+\set VERBOSITY terse
+SELECT val_deferred();
+\set VERBOSITY default
+
+-- Replacing a function repeatedly must not accumulate anything: the DDL path used
+-- to reset the entire context cache, which could not free the old contexts, so a
+-- loop of CREATE OR REPLACE grew the backend without bound and then crashed it.
+-- 200 replacements is far too few to show the growth, but it does prove the
+-- invalidation itself works -- each call must see the new body.
+CREATE FUNCTION val_churn(n int) RETURNS int LANGUAGE plpgsql AS $$
+DECLARE i int; r int; bad int := 0;
+BEGIN
+  FOR i IN 1..n LOOP
+    EXECUTE format('CREATE OR REPLACE FUNCTION val_v() RETURNS int LANGUAGE pljs AS $b$ return %s; $b$', i);
+    EXECUTE 'SELECT val_v()' INTO r;
+    IF r <> i THEN bad := bad + 1; END IF;
+  END LOOP;
+  RETURN bad;
+END $$;
+
+SELECT val_churn(200) AS stale_results;
+
+DROP FUNCTION val_churn(int);
+DROP FUNCTION val_v();
+DROP TRIGGER val_tr ON val_t;
+DROP FUNCTION val_trigger();
+DROP TABLE val_t;
+DROP FUNCTION val_return();
+DROP FUNCTION val_args(int, text);
+DROP FUNCTION val_novoid();
+DROP FUNCTION val_deferred();

--- a/sql/types.sql
+++ b/sql/types.sql
@@ -21,7 +21,12 @@ CREATE FUNCTION int4_to_text(x int4) RETURNS text AS $$ return x; $$ LANGUAGE pl
 SELECT int4_to_text(123);
 CREATE FUNCTION text_to_int4(x text) RETURNS int4 AS $$ return x; $$ LANGUAGE pljs;
 SELECT text_to_int4('123');
+-- A string is parsed by int4's input function, so text that is not an integer
+-- raises instead of silently becoming 0, which is what routing it through a
+-- double produced.
 SELECT text_to_int4('abc');
+-- Out of range likewise raises rather than wrapping.
+SELECT text_to_int4('2147483648');
 
 -- ARRAYS
 CREATE FUNCTION return_array() RETURNS TEXT[] AS $$ return ["foo", "bar"]; $$LANGUAGE pljs;

--- a/src/cache.c
+++ b/src/cache.c
@@ -242,9 +242,13 @@ void pljs_function_cache_to_context(pljs_context *context,
 
   memcpy(context->function->proname, function_entry->proname, NAMEDATALEN);
 
-  context->function->prosrc = (char *)palloc(NAMEDATALEN);
-
-  memcpy(context->function->prosrc, function_entry->prosrc, NAMEDATALEN);
+  /*
+   * prosrc is the (variable-length) function body, not a NAMEDATALEN name.
+   * Copying a fixed NAMEDATALEN bytes truncated bodies longer than 63 chars
+   * and over-read the source allocation for shorter ones.  pstrdup copies
+   * exactly the right length now that the cached copy is NUL-terminated.
+   */
+  context->function->prosrc = pstrdup(function_entry->prosrc);
 }
 
 /**
@@ -275,11 +279,14 @@ void pljs_context_to_function_cache(pljs_function_cache_value *function_entry,
 
   memcpy(function_entry->proname, context->function->proname, NAMEDATALEN);
 
-  function_entry->prosrc =
-      (char *)palloc(strlen(context->function->prosrc) + 1);
-
-  memcpy(function_entry->prosrc, context->function->prosrc,
-         strlen(context->function->prosrc));
+  /*
+   * Copy the full body including its NUL terminator.  The previous code
+   * allocated strlen+1 but memcpy'd only strlen bytes, leaving the final byte
+   * uninitialized (palloc does not zero), so the cached string was not
+   * NUL-terminated and any later read walked off the end.  We are in
+   * cache_memory_context here, so pstrdup allocates in the right place.
+   */
+  function_entry->prosrc = pstrdup(context->function->prosrc);
 
   MemoryContextSwitchTo(old_context);
 }

--- a/src/cache.c
+++ b/src/cache.c
@@ -49,6 +49,63 @@ void pljs_cache_init(void) {
 }
 
 /**
+ * @brief Drops the cached compiled form of one function, in every user's cache.
+ *
+ * Used when a function is created or replaced, so the next call recompiles it.
+ *
+ * The alternative -- pljs_cache_reset() -- destroys every per-user JSContext and
+ * rebuilds it on the next call.  JS_FreeContext() will not free a context that
+ * still has live references into it, so the old one is not necessarily reclaimed,
+ * and a backend doing repeated DDL grows without bound.  Removing a single entry
+ * keeps every JSContext alive and owned, so nothing is orphaned and nothing
+ * dangles -- including when the DDL is executed from inside a running pljs
+ * function via pljs.execute(), where freeing the context we are executing in
+ * would be fatal.
+ *
+ * @param fn_oid #Oid - the function whose compiled form is now stale
+ */
+void pljs_cache_function_remove(Oid fn_oid) {
+  HASH_SEQ_STATUS status;
+  pljs_context_cache_value *ctx_hvalue;
+
+  if (pljs_context_HashTable == NULL) {
+    return;
+  }
+
+  hash_seq_init(&status, pljs_context_HashTable);
+
+  while ((ctx_hvalue =
+              (pljs_context_cache_value *)hash_seq_search(&status)) != NULL) {
+    bool found = false;
+    pljs_function_cache_value *value;
+
+    if (ctx_hvalue->function_hash_table == NULL) {
+      continue;
+    }
+
+    value = (pljs_function_cache_value *)hash_search(
+        ctx_hvalue->function_hash_table, &fn_oid, HASH_FIND, &found);
+
+    if (!found || value == NULL) {
+      continue;
+    }
+
+    /*
+     * Drop our reference to the compiled function before the entry goes away;
+     * this is its only owner, so otherwise it leaks on the QuickJS heap.
+     */
+    JS_FreeValue(value->ctx, value->fn);
+
+    if (value->prosrc != NULL) {
+      pfree(value->prosrc);
+      value->prosrc = NULL;
+    }
+
+    hash_search(ctx_hvalue->function_hash_table, &fn_oid, HASH_REMOVE, NULL);
+  }
+}
+
+/**
  * @brief Clears all caches and recreates them.
  */
 void pljs_cache_reset(void) {

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,5 +1,6 @@
 #include "postgres.h"
 
+#include "access/htup_details.h"
 #include "utils/memutils.h"
 
 #include "pljs.h"
@@ -282,7 +283,8 @@ void pljs_cache_function_add(pljs_context *context) {
  * @param fn_oid #Oid
  * @returns #pljs_function_cache_value that is found, or `NULL` if not found
  */
-pljs_function_cache_value *pljs_cache_function_find(Oid user_id, Oid fn_oid) {
+pljs_function_cache_value *pljs_cache_function_find(Oid user_id, Oid fn_oid,
+                                                    HeapTuple proctuple) {
   bool found;
 
   // Search for the context.
@@ -298,6 +300,33 @@ pljs_function_cache_value *pljs_cache_function_find(Oid user_id, Oid fn_oid) {
   // Search for the function inside of the context.
   pljs_function_cache_value *value = (pljs_function_cache_value *)hash_search(
       ctx_hvalue->function_hash_table, &fn_oid, HASH_FIND, &found);
+
+  if (!found || value == NULL) {
+    return NULL;
+  }
+
+  /*
+   * A hit is only usable if it was compiled from the pg_proc tuple that is
+   * current now.  CREATE OR REPLACE writes a new tuple version, and the OID is
+   * unchanged, so the entry would otherwise still match and the backend would
+   * go on running the previous body.
+   *
+   * The validator drops the entry directly, which covers the backend issuing
+   * the DDL.  It cannot cover any other backend: pljs registers no syscache
+   * invalidation callback, so nothing else tells them.  Before this check, a
+   * session that had already called a function kept running the old body for
+   * the rest of its life, however many times the function was replaced.
+   *
+   * This also settles DROP FUNCTION followed by OID reuse, where a new function
+   * inherits the OID of the old one: the tuple is a different tuple, so the
+   * mismatch is detected rather than the old body being run under the new name.
+   */
+  if (HeapTupleIsValid(proctuple) &&
+      (value->fn_xmin != HeapTupleHeaderGetRawXmin(proctuple->t_data) ||
+       !ItemPointerEquals(&value->fn_tid, &proctuple->t_self))) {
+    pljs_cache_function_remove(fn_oid);
+    return NULL;
+  }
 
   return value;
 }
@@ -360,6 +389,9 @@ void pljs_context_to_function_cache(pljs_function_cache_value *function_entry,
   function_entry->trigger = context->function->trigger;
   function_entry->is_srf = context->function->is_srf;
   function_entry->typeclass = context->function->typeclass;
+
+  function_entry->fn_xmin = context->function->fn_xmin;
+  function_entry->fn_tid = context->function->fn_tid;
 
   function_entry->fn = context->js_function;
   function_entry->nargs = context->function->inargs;

--- a/src/cache.c
+++ b/src/cache.c
@@ -52,6 +52,40 @@ void pljs_cache_init(void) {
  * @brief Clears all caches and recreates them.
  */
 void pljs_cache_reset(void) {
+  HASH_SEQ_STATUS status;
+  pljs_context_cache_value *ctx_hvalue;
+
+  /*
+   * Free the QuickJS side before dropping the Postgres memory that points at
+   * it.  hash_destroy() and MemoryContextDelete() below reclaim only the
+   * palloc'd entries; the JSContexts and compiled functions they reference live
+   * on the libc heap and would otherwise be orphaned inside the runtime with no
+   * owner left to free them.
+   */
+  if (pljs_context_HashTable != NULL) {
+    hash_seq_init(&status, pljs_context_HashTable);
+
+    while ((ctx_hvalue = (pljs_context_cache_value *)hash_seq_search(&status)) !=
+           NULL) {
+      if (ctx_hvalue->function_hash_table != NULL) {
+        HASH_SEQ_STATUS fstatus;
+        pljs_function_cache_value *value;
+
+        hash_seq_init(&fstatus, ctx_hvalue->function_hash_table);
+
+        while ((value = (pljs_function_cache_value *)hash_seq_search(
+                    &fstatus)) != NULL) {
+          JS_FreeValue(value->ctx, value->fn);
+        }
+      }
+
+      if (ctx_hvalue->ctx != NULL) {
+        JS_FreeContext(ctx_hvalue->ctx);
+        ctx_hvalue->ctx = NULL;
+      }
+    }
+  }
+
   hash_destroy(pljs_context_HashTable);
   MemoryContextDelete(cache_memory_context);
   pljs_cache_init();

--- a/src/functions.c
+++ b/src/functions.c
@@ -1079,8 +1079,31 @@ static JSValue pljs_return_next(JSContext *ctx, JSValueConst this_val, int argc,
       return js_throw("argument must be an object", ctx);
     }
 
-    if (!pljs_jsvalue_object_contains_all_column_names(argv[0], ctx,
-                                                       retstate->tuple_desc)) {
+    char *missing_colname = NULL;
+    char *provided_keys = NULL;
+
+    if (!pljs_jsvalue_object_contains_all_column_names(
+            argv[0], ctx, retstate->tuple_desc, &missing_colname,
+            &provided_keys)) {
+      /*
+       * Name the column that is missing and list what the object did offer.
+       * The bare "field name / property name mismatch" gave the author nothing
+       * to act on, and the usual cause is a case difference -- JavaScript
+       * property names are case sensitive while PostgreSQL folds unquoted
+       * identifiers to lower case, so a `MixedCol` key never matches a
+       * `mixedcol` column.
+       */
+      if (missing_colname != NULL) {
+        return js_throw(psprintf("return_next: result column \"%s\" has no "
+                                 "matching property (object has: %s; property "
+                                 "names are case sensitive)",
+                                 missing_colname,
+                                 (provided_keys != NULL && *provided_keys)
+                                     ? provided_keys
+                                     : "no properties"),
+                        ctx);
+      }
+
       return js_throw("field name / property name mismatch", ctx);
     }
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -776,7 +776,14 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
   char *nulls = NULL;
   int nparams = 0;
   int argcount;
-  Portal cursor;
+  /*
+   * Assigned inside the PG_TRY below and read after PG_END_TRY, which is the
+   * pattern PostgreSQL's coding conventions require volatile for: without it a
+   * compiler is free to keep it in a register that the longjmp clobbers.  Safe
+   * in practice today because the read only happens on the non-longjmp path,
+   * but that is a property of the current control flow rather than of the code.
+   */
+  Portal volatile cursor = NULL;
   bool cleanup_params = false;
 
   JSValue ptr = JS_GetPropertyStr(ctx, this_val, "plan");
@@ -889,6 +896,18 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
       JS_FreeValue(ctx, params);
     }
 
+    /*
+     * This path rolls back only an internal subtransaction and then returns a
+     * JavaScript error, so the enclosing transaction -- and therefore
+     * CurrentMemoryContext -- lives on.  Nothing else will reclaim these.
+     */
+    if (values) {
+      pfree(values);
+    }
+    if (nulls) {
+      pfree(nulls);
+    }
+
     return error;
   }
 
@@ -904,6 +923,14 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
 
   if (cleanup_params) {
     JS_FreeValue(ctx, params);
+  }
+
+  /* The portal holds its own copies; these were only needed for the open. */
+  if (values) {
+    pfree(values);
+  }
+  if (nulls) {
+    pfree(nulls);
   }
 
   return ret;

--- a/src/functions.c
+++ b/src/functions.c
@@ -429,8 +429,10 @@ static JSValue pljs_plan_execute(JSContext *ctx, JSValueConst this_val,
   }
 
   if (argcount != nparams) {
-    elog(ERROR, "plan expected %d arguments but %d were passed instead",
-         argcount, nparams);
+    ereport(ERROR,
+            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+             errmsg("plan expected %d arguments but %d were passed instead",
+                    argcount, nparams)));
   }
 
   if (nparams > 0) {
@@ -730,8 +732,10 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
   }
 
   if (argcount != nparams) {
-    elog(ERROR, "plan expected %d arguments but %d were passed instead",
-         argcount, nparams);
+    ereport(ERROR,
+            (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+             errmsg("plan expected %d arguments but %d were passed instead",
+                    argcount, nparams)));
   }
 
   if (nparams > 0) {

--- a/src/functions.c
+++ b/src/functions.c
@@ -350,47 +350,77 @@ static int pljs_execute_params(const char *sql, JSValue params,
                                JSContext *ctx) {
   int nparams = pljs_js_array_length(params, ctx);
   int status;
+
+  /*
+   * Everything this function allocates is scoped to a child context that is
+   * deleted on both the success and the error path.
+   *
+   * The frees used to sit after SPI_execute_plan_with_paramlist(), so any query
+   * that raised -- the common case in real code, and the whole point of a retry
+   * loop -- leaked all of it.  None of it is reclaimed by subtransaction
+   * rollback: the plan lives in the SPI procedure context and the rest in the
+   * caller's, both of which outlive the failed statement.
+   *
+   * The SPI plan is the exception that still needs explicit handling, because
+   * SPI_freeplan() is not memory-context based, hence the PG_CATCH below rather
+   * than a context delete alone.
+   */
+  MemoryContext parm_cxt = AllocSetContextCreate(
+      CurrentMemoryContext, "PLJS execute params", ALLOCSET_SMALL_SIZES);
+  MemoryContext old_cxt = MemoryContextSwitchTo(parm_cxt);
+
   Datum *values = palloc(sizeof(Datum) * nparams);
   char *nulls = palloc(sizeof(char) * nparams);
 
-  SPIPlanPtr plan;
-  pljs_param_state parstate = {.memory_context = CurrentMemoryContext,
-                               .param_types = 0};
-  ParamListInfo param_li;
-
-  plan = SPI_prepare_params(sql, pljs_variable_param_setup, &parstate, 0);
-
-  if (parstate.nparams != nparams) {
-    elog(ERROR, "parameter count mismatch: %d != %d", parstate.nparams,
-         nparams);
-  }
-  for (int i = 0; i < nparams; i++) {
-    JSValue param = JS_GetPropertyUint32(ctx, params, i);
-    bool is_null;
-
-    values[i] = pljs_jsvalue_to_datum(parstate.param_types[i], param, &is_null,
-                                      ctx, NULL);
-
-    JS_FreeValue(ctx, param);
-  }
-
-  param_li = pljs_setup_variable_paramlist(&parstate, values, nulls);
-  status = SPI_execute_plan_with_paramlist(plan, param_li, false, 0);
-
   /*
-   * SPI_prepare_params builds an *unsaved* plan in the current SPI procedure
-   * context, and pljs_variable_param_setup pallocs param_types there too.
-   * Neither is reclaimed until the enclosing pljs function returns, so a loop
-   * of parameterised pljs.execute() calls grew the SPI Proc context by a whole
-   * cached plan (~kilobytes) per iteration.  Free them now.
+   * NB: SPI_prepare_params() stores the address of this *stack-local* parstate
+   * in the plan's parserSetupArg, so the plan must not outlive this frame.  The
+   * SPI_freeplan() calls below are what guarantee that -- they are not an
+   * optimisation to be removed.
    */
-  SPI_freeplan(plan);
-  if (parstate.param_types) {
-    pfree(parstate.param_types);
+  pljs_param_state parstate = {.memory_context = parm_cxt, .param_types = 0};
+  SPIPlanPtr volatile plan = NULL;
+
+  PG_TRY();
+  {
+    plan = SPI_prepare_params(sql, pljs_variable_param_setup, &parstate, 0);
+
+    if (parstate.nparams != nparams) {
+      ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                      errmsg("parameter count mismatch: %d != %d",
+                             parstate.nparams, nparams)));
+    }
+
+    for (int i = 0; i < nparams; i++) {
+      JSValue param = JS_GetPropertyUint32(ctx, params, i);
+      bool is_null;
+
+      values[i] = pljs_jsvalue_to_datum(parstate.param_types[i], param,
+                                        &is_null, ctx, NULL);
+      nulls[i] = is_null ? 'n' : ' ';
+
+      JS_FreeValue(ctx, param);
+    }
+
+    ParamListInfo param_li =
+        pljs_setup_variable_paramlist(&parstate, values, nulls);
+
+    status = SPI_execute_plan_with_paramlist(plan, param_li, false, 0);
   }
-  pfree(param_li);
-  pfree(values);
-  pfree(nulls);
+  PG_CATCH();
+  {
+    if (plan) {
+      SPI_freeplan(plan);
+    }
+    MemoryContextSwitchTo(old_cxt);
+    MemoryContextDelete(parm_cxt);
+    PG_RE_THROW();
+  }
+  PG_END_TRY();
+
+  SPI_freeplan(plan);
+  MemoryContextSwitchTo(old_cxt);
+  MemoryContextDelete(parm_cxt);
 
   return status;
 }

--- a/src/functions.c
+++ b/src/functions.c
@@ -1007,9 +1007,14 @@ static JSValue pljs_find_function(JSContext *ctx, JSValueConst this_val,
   {
     Oid funcoid;
 
-    if (!pljs_has_permission_to_execute(signature)) {
-      return func;
-    } else {
+    /*
+     * NB: never `return` from inside a PG_TRY block.  Doing so leaves
+     * PG_exception_stack pointing at this frame's (now dead) sigjmp_buf, so
+     * the next ereport(ERROR) siglongjmp()s into a freed stack frame and the
+     * backend crashes.  When permission is denied we leave `func` as
+     * JS_UNDEFINED and fall through to the shared cleanup/return below.
+     */
+    if (pljs_has_permission_to_execute(signature)) {
       if (strchr(signature, '(') == NULL) {
         funcoid = DatumGetObjectId(
             DirectFunctionCall1(regprocin, CStringGetDatum(signature)));

--- a/src/functions.c
+++ b/src/functions.c
@@ -625,16 +625,25 @@ static JSValue pljs_prepare(JSContext *ctx, JSValueConst this_val, int argc,
 
   sql = JS_ToCString(ctx, argv[0]);
 
+  /*
+   * Allocate parstate in CacheMemoryContext so it survives beyond the current
+   * call_function execution_context (which gets deleted on return).
+   * param_types is palloc'd via parstate->memory_context so it must point to
+   * the same long-lived context.  We allocate it *before* PG_TRY so the
+   * pointer is stable for the cleanup path (and not at risk of being clobbered
+   * across the longjmp), and so the PG_CATCH branch can free it: because it
+   * lives in the permanent CacheMemoryContext, a failed SPI_prepare would
+   * otherwise leak it (and its param_types) for the life of the backend.
+   */
+  if (argc > 1) {
+    parstate =
+        MemoryContextAllocZero(CacheMemoryContext, sizeof(pljs_param_state));
+    parstate->memory_context = CacheMemoryContext;
+  }
+
   PG_TRY();
   {
-    if (argc > 1) {
-      /* Allocate parstate in CacheMemoryContext so it survives beyond the
-       * current call_function execution_context (which gets deleted on
-       * return).  param_types is palloc'd via parstate->memory_context so
-       * it must point to the same long-lived context. */
-      parstate = MemoryContextAllocZero(CacheMemoryContext,
-                                        sizeof(pljs_param_state));
-      parstate->memory_context = CacheMemoryContext;
+    if (parstate) {
       initial = SPI_prepare_params(sql, pljs_variable_param_setup, parstate, 0);
     } else {
       initial = SPI_prepare(sql, nparams, types);
@@ -646,6 +655,17 @@ static JSValue pljs_prepare(JSContext *ctx, JSValueConst this_val, int argc,
 
   PG_CATCH();
   {
+    if (parstate) {
+      if (parstate->param_types) {
+        pfree(parstate->param_types);
+      }
+      pfree(parstate);
+    }
+
+    if (types != NULL) {
+      pfree(types);
+    }
+
     if (cleanup_params) {
       JS_FreeValue(ctx, params);
     }

--- a/src/functions.c
+++ b/src/functions.c
@@ -377,6 +377,18 @@ static int pljs_execute_params(const char *sql, JSValue params,
   param_li = pljs_setup_variable_paramlist(&parstate, values, nulls);
   status = SPI_execute_plan_with_paramlist(plan, param_li, false, 0);
 
+  /*
+   * SPI_prepare_params builds an *unsaved* plan in the current SPI procedure
+   * context, and pljs_variable_param_setup pallocs param_types there too.
+   * Neither is reclaimed until the enclosing pljs function returns, so a loop
+   * of parameterised pljs.execute() calls grew the SPI Proc context by a whole
+   * cached plan (~kilobytes) per iteration.  Free them now.
+   */
+  SPI_freeplan(plan);
+  if (parstate.param_types) {
+    pfree(parstate.param_types);
+  }
+  pfree(param_li);
   pfree(values);
   pfree(nulls);
 
@@ -531,6 +543,14 @@ static JSValue pljs_plan_execute(JSContext *ctx, JSValueConst this_val,
       paramLI = pljs_setup_variable_paramlist(plan->parstate, values, nulls);
       status = SPI_execute_plan_with_paramlist(plan->plan, paramLI, false, 0);
 
+      /*
+       * paramLI lives in the caller's (SPI Proc) context, which is not
+       * released until the enclosing function returns; SPI copies what it
+       * needs, so free it now.  Without this, a function that loops
+       * plan.execute() over a large batch grows the SPI Proc context by one
+       * ParamListInfo per iteration.
+       */
+      pfree(paramLI);
     } else {
       status = SPI_execute_plan(plan->plan, values, nulls, false, 0);
     }
@@ -892,6 +912,8 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
           pljs_setup_variable_paramlist(plan->parstate, values, nulls);
       cursor =
           SPI_cursor_open_with_paramlist(NULL, plan->plan, param_li, false);
+      /* the portal copies the params into its own context; free ours */
+      pfree(param_li);
     } else {
       cursor = SPI_cursor_open(NULL, plan->plan, values, nulls, false);
     }

--- a/src/functions.c
+++ b/src/functions.c
@@ -328,6 +328,7 @@ static JSValue pljs_execute(JSContext *ctx, JSValueConst this_val, int argc,
   CurrentResourceOwner = m_resowner;
 
   JSValue ret = pljs_spi_result_to_jsvalue(status, ctx);
+  SPI_freetuptable(SPI_tuptable);
 
   return ret;
 }

--- a/src/functions.c
+++ b/src/functions.c
@@ -602,13 +602,37 @@ static JSValue pljs_plan_free(JSContext *ctx, JSValueConst this_val, int argc,
 
   plan = JS_GetOpaque(ptr, js_prepared_statement_handle_id);
 
-  pljs_free_plan_struct(plan);
-
   /*
-   * Clear the opaque so the handle's GC finalizer does not free the same plan
-   * again once this handle object is collected.
+   * Clear the opaque *before* freeing, and free under PG_TRY.
+   *
+   * SPI_freeplan() raises on an invalid plan pointer, and this is a C function
+   * QuickJS called, so letting that error out siglongjmps past QuickJS's live
+   * stack frames -- see pljs_return_next() for what that costs.  Clearing the
+   * opaque first also means a failed free cannot leave the handle pointing at a
+   * plan the GC finalizer would then try to free again.
    */
   JS_SetOpaque(ptr, NULL);
+
+  PG_TRY();
+  {
+    pljs_free_plan_struct(plan);
+  }
+  PG_CATCH();
+  {
+    MemoryContext m_mcontext = CurrentMemoryContext;
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+
+    JS_SetPropertyStr(ctx, this_val, "plan", JS_NULL);
+    JS_FreeValue(ctx, ptr);
+
+    return error;
+  }
+  PG_END_TRY();
 
   JS_SetPropertyStr(ctx, this_val, "plan", JS_NULL);
 
@@ -1904,8 +1928,6 @@ static JSValue pljs_get_window_object(JSContext *ctx, JSValueConst this_val,
 
 static JSValue pljs_subtransaction(JSContext *ctx, JSValueConst this_val,
                                    int argc, JSValueConst *argv) {
-  JSValue result = JS_UNDEFINED;
-
   if (argc < 1) {
     return JS_UNDEFINED;
   }
@@ -1921,21 +1943,81 @@ static JSValue pljs_subtransaction(JSContext *ctx, JSValueConst this_val,
   ResourceOwner m_resowner = CurrentResourceOwner;
   MemoryContext m_mcontext = CurrentMemoryContext;
 
-  BeginInternalSubTransaction(NULL);
-  MemoryContextSwitchTo(m_mcontext);
+  /*
+   * How far we got, so the PG_CATCH knows what it is cleaning up.  Assigned in
+   * the PG_TRY and read in the PG_CATCH, hence volatile.
+   *
+   *   0 - no subtransaction started
+   *   1 - subtransaction open, running the callback
+   *   2 - committing or rolling it back
+   */
+  volatile int stage = 0;
+  volatile JSValue result = JS_UNDEFINED;
 
-  result = JS_Call(ctx, argv[0], JS_UNDEFINED, 0, NULL);
+  /*
+   * A PostgreSQL error must not escape this function.  pljs.subtransaction() is
+   * a C function that QuickJS called, so an ereport(ERROR) here siglongjmps past
+   * QuickJS's live stack frames and leaves the runtime's frame list pointing at
+   * dead ones; the session then crashes later, in whatever next builds an
+   * Error's backtrace.  See pljs_return_next() for the full mechanism.
+   *
+   * BeginInternalSubTransaction() and ReleaseCurrentSubTransaction() both raise
+   * in ordinary operation, so this needs no bad input to reach.
+   */
+  PG_TRY();
+  {
+    BeginInternalSubTransaction(NULL);
+    stage = 1;
+    MemoryContextSwitchTo(m_mcontext);
 
-  bool success = !JS_IsException(result);
+    result = JS_Call(ctx, argv[0], JS_UNDEFINED, 0, NULL);
 
-  if (success) {
-    ReleaseCurrentSubTransaction();
-  } else {
-    RollbackAndReleaseCurrentSubTransaction();
+    bool success = !JS_IsException(result);
+
+    stage = 2;
+
+    if (success) {
+      ReleaseCurrentSubTransaction();
+    } else {
+      RollbackAndReleaseCurrentSubTransaction();
+    }
+
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
   }
+  PG_CATCH();
+  {
+    MemoryContextSwitchTo(m_mcontext);
 
-  MemoryContextSwitchTo(m_mcontext);
-  CurrentResourceOwner = m_resowner;
+    /*
+     * A failure while committing or rolling the subtransaction back leaves no
+     * valid state to resume into, exactly as for pljs.commit(): re-throw rather
+     * than handing back a catchable exception and letting the function continue.
+     */
+    if (stage == 2) {
+      CurrentResourceOwner = m_resowner;
+      PG_RE_THROW();
+    }
+
+    if (stage == 1) {
+      RollbackAndReleaseCurrentSubTransaction();
+      MemoryContextSwitchTo(m_mcontext);
+    }
+
+    CurrentResourceOwner = m_resowner;
+
+    JS_FreeValue(ctx, result);
+
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+
+    return error;
+  }
+  PG_END_TRY();
 
   return result;
 }

--- a/src/functions.c
+++ b/src/functions.c
@@ -12,6 +12,7 @@
 #include "utils/elog.h"
 #include "utils/fmgrprotos.h"
 #include "utils/palloc.h"
+#include "utils/memutils.h"
 #include "utils/resowner.h"
 #include "windowapi.h"
 
@@ -627,8 +628,13 @@ static JSValue pljs_prepare(JSContext *ctx, JSValueConst this_val, int argc,
   PG_TRY();
   {
     if (argc > 1) {
-      parstate = palloc0(sizeof(pljs_param_state));
-      parstate->memory_context = CurrentMemoryContext;
+      /* Allocate parstate in CacheMemoryContext so it survives beyond the
+       * current call_function execution_context (which gets deleted on
+       * return).  param_types is palloc'd via parstate->memory_context so
+       * it must point to the same long-lived context. */
+      parstate = MemoryContextAllocZero(CacheMemoryContext,
+                                        sizeof(pljs_param_state));
+      parstate->memory_context = CacheMemoryContext;
       initial = SPI_prepare_params(sql, pljs_variable_param_setup, parstate, 0);
     } else {
       initial = SPI_prepare(sql, nparams, types);
@@ -660,7 +666,8 @@ static JSValue pljs_prepare(JSContext *ctx, JSValueConst this_val, int argc,
 
   JS_SetPropertyFunctionList(ctx, ret, js_plan_funcs, 4);
 
-  plan = palloc(sizeof(pljs_plan));
+  /* Allocate plan in CacheMemoryContext for the same reason as parstate. */
+  plan = MemoryContextAlloc(CacheMemoryContext, sizeof(pljs_plan));
 
   plan->parstate = parstate;
   plan->plan = saved;

--- a/src/functions.c
+++ b/src/functions.c
@@ -384,6 +384,62 @@ static int pljs_execute_params(const char *sql, JSValue params,
 }
 
 /**
+ * @brief Frees a #pljs_plan and everything it owns.
+ *
+ * Shared by the explicit `plan.free()` path and the GC finalizer.  All of the
+ * members live in long-lived contexts (the SPI plan is a saved plan, parstate
+ * and its param_types are in CacheMemoryContext), so this is safe to call at
+ * any time, including from a finalizer that may run outside a transaction.
+ * Note the previous free path leaked parstate->param_types; it is reclaimed
+ * here.
+ */
+static void pljs_free_plan_struct(pljs_plan *plan) {
+  if (plan == NULL) {
+    return;
+  }
+
+  if (plan->plan) {
+    SPI_freeplan(plan->plan);
+  }
+
+  if (plan->parstate) {
+    if (plan->parstate->param_types) {
+      pfree(plan->parstate->param_types);
+    }
+    pfree(plan->parstate);
+  }
+
+  pfree(plan);
+}
+
+/**
+ * @brief GC finalizer for the prepared-statement handle class.
+ *
+ * Without this, a plan object that JavaScript prepares but never explicitly
+ * `.free()`s leaks its saved SPI plan and CacheMemoryContext parstate for the
+ * life of the backend -- e.g. preparing 20k plans in a loop grew
+ * CacheMemoryContext from ~1MB to ~64MB with no way to reclaim it.  The
+ * finalizer runs when the handle becomes unreachable so the leak is bounded by
+ * the GC interval instead of being permanent.  plan.free() clears the opaque,
+ * so this is a no-op after an explicit free (no double free).
+ */
+static void pljs_plan_handle_finalizer(JSRuntime *rt, JSValue val) {
+  pljs_plan *plan = JS_GetOpaque(val, js_prepared_statement_handle_id);
+
+  pljs_free_plan_struct(plan);
+}
+
+static const JSClassDef pljs_plan_handle_class = {
+    "PljsPreparedStatement",
+    .finalizer = pljs_plan_handle_finalizer,
+};
+
+void pljs_register_js_classes(JSRuntime *runtime) {
+  JS_NewClassID(&js_prepared_statement_handle_id);
+  JS_NewClass(runtime, js_prepared_statement_handle_id, &pljs_plan_handle_class);
+}
+
+/**
  * @brief Javascript function `plan.execute`.
  *
  * Javascript function that executes a Postgres plan and returns
@@ -546,17 +602,13 @@ static JSValue pljs_plan_free(JSContext *ctx, JSValueConst this_val, int argc,
 
   plan = JS_GetOpaque(ptr, js_prepared_statement_handle_id);
 
-  if (plan) {
-    if (plan->plan) {
-      SPI_freeplan(plan->plan);
-    }
+  pljs_free_plan_struct(plan);
 
-    if (plan->parstate) {
-      pfree(plan->parstate);
-    }
-
-    pfree(plan);
-  }
+  /*
+   * Clear the opaque so the handle's GC finalizer does not free the same plan
+   * again once this handle object is collected.
+   */
+  JS_SetOpaque(ptr, NULL);
 
   JS_SetPropertyStr(ctx, this_val, "plan", JS_NULL);
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -302,6 +302,8 @@ static JSValue pljs_execute(JSContext *ctx, JSValueConst this_val, int argc,
     RollbackAndReleaseCurrentSubTransaction();
     MemoryContextSwitchTo(m_mcontext);
     CurrentResourceOwner = m_resowner;
+    FlushErrorState();
+    FreeErrorData(edata);
 
     if (cleanup_params) {
       JS_FreeValue(ctx, params);
@@ -480,6 +482,8 @@ static JSValue pljs_plan_execute(JSContext *ctx, JSValueConst this_val,
 
     RollbackAndReleaseCurrentSubTransaction();
     CurrentResourceOwner = m_resowner;
+    FlushErrorState();
+    FreeErrorData(edata);
 
     if (values) {
       pfree(values);

--- a/src/functions.c
+++ b/src/functions.c
@@ -921,6 +921,32 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
   JS_SetPropertyStr(ctx, ret, "name", str);
   JS_SetPropertyFunctionList(ctx, ret, js_cursor_funcs, 4);
 
+  /*
+   * Keep the plan handle reachable from the cursor.
+   *
+   * pljs_plan_handle_finalizer() calls SPI_freeplan(), and it runs as soon as
+   * the plan handle becomes unreachable -- which the natural idiom makes
+   * immediate:
+   *
+   *   var c = pljs.prepare('select ... where id = $1', ['int']).cursor([1]);
+   *   while (c.fetch()) { ... }
+   *
+   * The plan object is unreachable from that second line on, but the portal
+   * opened from it is still live and is re-entered by fetch/move/close.
+   * SPI_freeplan -> DropCachedPlan sets plansource->magic = 0 and deletes the
+   * plansource's context, and SPI_freeplan's own contract says a plan in use
+   * must not be freed.  The portal holds a refcount on the CachedPlan, not on
+   * the CachedPlanSource, so whether that crashes or merely reads freed memory
+   * depends on plancache internals that are not part of any contract.
+   *
+   * Holding an owned reference here means the plan cannot be collected before
+   * the cursor is, so the finalizer cannot run underneath an open portal.
+   * JS_GetPropertyStr returns a new owned reference and JS_SetPropertyStr
+   * consumes it, so this transfers cleanly without touching the error paths
+   * above.
+   */
+  JS_SetPropertyStr(ctx, ret, "plan", JS_GetPropertyStr(ctx, this_val, "plan"));
+
   if (cleanup_params) {
     JS_FreeValue(ctx, params);
   }

--- a/src/functions.c
+++ b/src/functions.c
@@ -822,17 +822,41 @@ static JSValue pljs_plan_cursor_fetch(JSContext *ctx, JSValueConst this_val,
     }
   }
 
+  /*
+   * Guard the fetch with an internal subtransaction (same pattern as
+   * pljs_execute).  The previous code called SPI_rollback()+SPI_finish() in
+   * the error handler, which (a) double-finishes the SPI connection owned by
+   * call_function and (b) raises "invalid transaction termination" in an
+   * atomic context, masking the real error (e.g. a division-by-zero that
+   * surfaces lazily during the fetch).  With the subtransaction we can roll
+   * back cleanly and re-raise the actual error into JS so it is catchable.
+   */
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
+
   PG_TRY();
   {
+    BeginInternalSubTransaction(NULL);
+    MemoryContextSwitchTo(m_mcontext);
     SPI_cursor_fetch(cursor, forward, nfetch);
   }
   PG_CATCH();
   {
-    SPI_rollback();
-    SPI_finish();
-    return js_throw("Unable to fetch", ctx);
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+    RollbackAndReleaseCurrentSubTransaction();
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
+    FlushErrorState();
+    FreeErrorData(edata);
+    return error;
   }
   PG_END_TRY();
+
+  ReleaseCurrentSubTransaction();
+  MemoryContextSwitchTo(m_mcontext);
+  CurrentResourceOwner = m_resowner;
 
   if (SPI_processed > 0) {
     if (!wantarray) {
@@ -888,15 +912,34 @@ static JSValue pljs_plan_cursor_move(JSContext *ctx, JSValueConst this_val,
     forward = false;
   }
 
+  /* Subtransaction guard so a move error rolls back cleanly and re-raises the
+   * real error into JS (see pljs_plan_cursor_fetch). */
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
+
   PG_TRY();
   {
+    BeginInternalSubTransaction(NULL);
+    MemoryContextSwitchTo(m_mcontext);
     SPI_cursor_move(cursor, forward, nmove);
   }
   PG_CATCH();
   {
-    return js_throw("Unable to fetch", ctx);
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+    RollbackAndReleaseCurrentSubTransaction();
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
+    FlushErrorState();
+    FreeErrorData(edata);
+    return error;
   }
   PG_END_TRY();
+
+  ReleaseCurrentSubTransaction();
+  MemoryContextSwitchTo(m_mcontext);
+  CurrentResourceOwner = m_resowner;
 
   return JS_UNDEFINED;
 }
@@ -922,19 +965,38 @@ static JSValue pljs_plan_cursor_close(JSContext *ctx, JSValueConst this_val,
     return js_throw("Unable to find cursor", ctx);
   }
 
+  /* Subtransaction guard; the previous SPI_rollback()+SPI_finish() here
+   * double-finished the connection owned by call_function and raised
+   * "invalid transaction termination" in an atomic context (see
+   * pljs_plan_cursor_fetch). */
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
+
   PG_TRY();
   {
+    BeginInternalSubTransaction(NULL);
+    MemoryContextSwitchTo(m_mcontext);
     SPI_cursor_close(cursor);
   }
   PG_CATCH();
   {
-    SPI_rollback();
-    SPI_finish();
-    return js_throw("Unable to close cursor", ctx);
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+    RollbackAndReleaseCurrentSubTransaction();
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
+    FlushErrorState();
+    FreeErrorData(edata);
+    return error;
   }
   PG_END_TRY();
 
-  JSValue ret = JS_NewInt32(ctx, cursor ? 1 : 0);
+  ReleaseCurrentSubTransaction();
+  MemoryContextSwitchTo(m_mcontext);
+  CurrentResourceOwner = m_resowner;
+
+  JSValue ret = JS_NewInt32(ctx, 1);
 
   return ret;
 }

--- a/src/functions.c
+++ b/src/functions.c
@@ -1438,6 +1438,32 @@ static JSValue pljs_return_next_internal(JSContext *ctx, JSValueConst this_val, 
   }
 
   if (retstate->is_composite) {
+    /*
+     * null/undefined emits an all-NULL row rather than raising "argument must
+     * be an object".  A composite-returning set can legitimately contain a NULL
+     * row -- plpgsql writes exactly that with RETURN NEXT NULL -- and there was
+     * no way to express it, so a caller mapping a nullable source row had to
+     * skip it or invent a sentinel.  This also matches the rest of the
+     * conversion surface, where null and undefined are SQL NULL everywhere.
+     */
+    if (JS_IsNull(argv[0]) || JS_IsUndefined(argv[0])) {
+      bool *nulls = (bool *)palloc(sizeof(bool) * retstate->tuple_desc->natts);
+      Datum *values =
+          (Datum *)palloc0(sizeof(Datum) * retstate->tuple_desc->natts);
+
+      for (int i = 0; i < retstate->tuple_desc->natts; i++) {
+        nulls[i] = true;
+      }
+
+      tuplestore_putvalues(retstate->tuple_store_state, retstate->tuple_desc,
+                           values, nulls);
+
+      pfree(nulls);
+      pfree(values);
+
+      return JS_UNDEFINED;
+    }
+
     if (!JS_IsObject(argv[0])) {
       return js_throw("argument must be an object", ctx);
     }

--- a/src/functions.c
+++ b/src/functions.c
@@ -45,6 +45,8 @@ static JSValue pljs_rollback(JSContext *, JSValueConst, int, JSValueConst *);
 static JSValue pljs_find_function(JSContext *, JSValueConst, int,
                                   JSValueConst *);
 static JSValue pljs_return_next(JSContext *, JSValueConst, int, JSValueConst *);
+static JSValue pljs_return_next_internal(JSContext *, JSValueConst, int,
+                                         JSValueConst *);
 
 static JSValue pljs_get_window_object(JSContext *, JSValueConst, int,
                                       JSValueConst *);
@@ -1216,7 +1218,7 @@ static JSValue pljs_find_function(JSContext *ctx, JSValueConst this_val,
  *
  * @returns #JSValue containing `undefined`
  */
-static JSValue pljs_return_next(JSContext *ctx, JSValueConst this_val, int argc,
+static JSValue pljs_return_next_internal(JSContext *ctx, JSValueConst this_val, int argc,
                                 JSValueConst *argv) {
   pljs_storage *storage = pljs_storage_for_context(ctx);
 
@@ -1279,6 +1281,63 @@ static JSValue pljs_return_next(JSContext *ctx, JSValueConst this_val, int argc,
   }
   return JS_UNDEFINED;
 }
+
+/**
+ * @brief Javascript function `pljs.return_next`.
+ *
+ * Wraps pljs_return_next_internal() so that a PostgreSQL error raised while
+ * converting the row -- an out-of-range integer, an unparseable numeric string,
+ * a NUL byte in a text value -- becomes a JavaScript exception instead of a
+ * longjmp.
+ *
+ * This is not defensive tidying.  return_next is a C function that QuickJS
+ * called, so QuickJS has live JSStackFrame structures on the C stack between us
+ * and the interpreter, linked from the runtime.  An ereport(ERROR) here
+ * siglongjmps straight past them, leaving rt->current_stack_frame pointing at
+ * frames that no longer exist.  The session then looks fine until anything walks
+ * that list -- which is what constructing an Error does, via build_backtrace --
+ * so a later, completely unrelated `throw new Error(...)`, typically in a
+ * trigger, segfaults the backend:
+ *
+ *     build_backtrace <- js_error_constructor <- JS_Call <- call_trigger
+ *
+ * A failing SETOF call followed by any trigger reproduces it in two statements.
+ * pljs_execute() has always converted PostgreSQL errors to JavaScript
+ * exceptions for the same reason; return_next did not, and became able to raise
+ * once the conversion paths started rejecting bad values instead of silently
+ * mangling them.
+ */
+static JSValue pljs_return_next(JSContext *ctx, JSValueConst this_val, int argc,
+                                JSValueConst *argv) {
+  MemoryContext m_mcontext = CurrentMemoryContext;
+  JSValue result = JS_UNDEFINED;
+
+  PG_TRY();
+  {
+    /*
+     * NB: assign, do not return, from inside PG_TRY -- a return here would leave
+     * PG_exception_stack pointing at this frame's dead sigjmp_buf.
+     */
+    result = pljs_return_next_internal(ctx, this_val, argc, argv);
+  }
+  PG_CATCH();
+  {
+    MemoryContextSwitchTo(m_mcontext);
+
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+
+    return error;
+  }
+  PG_END_TRY();
+
+  return result;
+}
+
 
 /**
  * @brief Javascript function `window.get_partition_local`.

--- a/src/functions.c
+++ b/src/functions.c
@@ -226,7 +226,7 @@ static JSValue pljs_elog(JSContext *ctx, JSValueConst this_val, int argc,
     {
       MemoryContextSwitchTo(m_mcontext);
       ErrorData *edata = CopyErrorData();
-      JSValue error = js_throw(edata->message, ctx);
+      JSValue error = js_throw_error_data(edata, ctx);
       FlushErrorState();
       FreeErrorData(edata);
 
@@ -297,7 +297,7 @@ static JSValue pljs_execute(JSContext *ctx, JSValueConst this_val, int argc,
     MemoryContextSwitchTo(m_mcontext);
 
     ErrorData *edata = CopyErrorData();
-    JSValue error = js_throw(edata->message, ctx);
+    JSValue error = js_throw_error_data(edata, ctx);
 
     RollbackAndReleaseCurrentSubTransaction();
     MemoryContextSwitchTo(m_mcontext);
@@ -478,7 +478,7 @@ static JSValue pljs_plan_execute(JSContext *ctx, JSValueConst this_val,
   {
     MemoryContextSwitchTo(m_mcontext);
     ErrorData *edata = CopyErrorData();
-    JSValue error = js_throw(edata->message, ctx);
+    JSValue error = js_throw_error_data(edata, ctx);
 
     RollbackAndReleaseCurrentSubTransaction();
     CurrentResourceOwner = m_resowner;

--- a/src/functions.c
+++ b/src/functions.c
@@ -752,10 +752,29 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
         plan->parstate ? plan->parstate->param_types[i] : 0, param, &is_null,
         ctx, NULL);
     nulls[i] = is_null ? 'n' : ' ';
+
+    /* plan.execute() frees its params; this path leaked one ref per bind. */
+    JS_FreeValue(ctx, param);
   }
+
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
 
   PG_TRY();
   {
+    /*
+     * Opening a cursor executes the query's start-up, so it can fail for any
+     * reason a query can.  Without a subtransaction to unwind, everything the
+     * failed attempt acquired -- syscache pins, locks, buffer pins -- leaks
+     * until the enclosing transaction ends ("WARNING: resource was not closed:
+     * cache pg_proc ... has count N", one per failed open).  fetch/move/close
+     * already guard this way; open did not.  On success
+     * ReleaseCurrentSubTransaction() reparents the new portal to the parent
+     * subtransaction (AtSubCommit_Portals), so the cursor stays usable.
+     */
+    BeginInternalSubTransaction(NULL);
+    MemoryContextSwitchTo(m_mcontext);
+
     if (plan->parstate) {
       ParamListInfo param_li =
           pljs_setup_variable_paramlist(plan->parstate, values, nulls);
@@ -768,14 +787,35 @@ static JSValue pljs_plan_cursor(JSContext *ctx, JSValueConst this_val, int argc,
 
   PG_CATCH();
   {
+    /*
+     * Flush the caught error (see pljs_commit(): five unflushed catches PANIC
+     * the whole cluster) and re-raise the real one.  The old "Error executing"
+     * string discarded the actual failure -- opening a cursor evaluates the
+     * query, so a division by zero, a permission failure or a missing relation
+     * all arrived in JS as the same opaque message.
+     */
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    RollbackAndReleaseCurrentSubTransaction();
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
+
     if (cleanup_params) {
       JS_FreeValue(ctx, params);
     }
 
-    return js_throw("Error executing", ctx);
+    return error;
   }
 
   PG_END_TRY();
+
+  ReleaseCurrentSubTransaction();
+  MemoryContextSwitchTo(m_mcontext);
+  CurrentResourceOwner = m_resowner;
   JSValue ret = JS_NewObject(ctx);
   JSValue str = JS_NewString(ctx, cursor->name);
   JS_SetPropertyStr(ctx, ret, "name", str);
@@ -1020,6 +1060,9 @@ static JSValue pljs_plan_to_string(JSContext *ctx, JSValueConst this_val,
  */
 static JSValue pljs_commit(JSContext *ctx, JSValueConst this_val, int argc,
                            JSValueConst *argv) {
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
+
   PG_TRY();
   {
     // HoldPinnedPortals();
@@ -1028,7 +1071,29 @@ static JSValue pljs_commit(JSContext *ctx, JSValueConst this_val, int argc,
   }
   PG_CATCH();
   {
-    return js_throw("Unable to commit", ctx);
+    /*
+     * The caught error MUST be flushed off the errordata stack.  Returning
+     * without FlushErrorState() leaves the entry there permanently: the stack
+     * is only ERRORDATA_STACK_SIZE (5) deep and is not unwound until the
+     * enclosing statement finishes, so five caught commit failures inside a
+     * single call make the sixth ereport() PANIC with "ERRORDATA_STACK_SIZE
+     * exceeded" -- which kills every backend in the cluster, not just this
+     * session.  A procedure that retries a failing commit in a loop (a
+     * deadlock, serialization failure, or full disk) hits this.
+     *
+     * Report the real Postgres error rather than a generic string, so the
+     * caller can tell a deadlock from a disk-full.
+     */
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
+
+    return error;
   }
   PG_END_TRY();
 
@@ -1044,6 +1109,9 @@ static JSValue pljs_commit(JSContext *ctx, JSValueConst this_val, int argc,
  */
 static JSValue pljs_rollback(JSContext *ctx, JSValueConst this_val, int argc,
                              JSValueConst *argv) {
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
+
   PG_TRY();
   {
     // HoldPinnedPortals();
@@ -1052,7 +1120,17 @@ static JSValue pljs_rollback(JSContext *ctx, JSValueConst this_val, int argc,
   }
   PG_CATCH();
   {
-    return js_throw("Unable to rollback", ctx);
+    /* Flush the caught error; see pljs_commit() for why this is mandatory. */
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
+
+    return error;
   }
   PG_END_TRY();
 
@@ -1073,6 +1151,8 @@ static JSValue pljs_find_function(JSContext *ctx, JSValueConst this_val,
   }
   const char *signature = JS_ToCString(ctx, argv[0]);
   JSValue func = JS_UNDEFINED;
+  ResourceOwner m_resowner = CurrentResourceOwner;
+  MemoryContext m_mcontext = CurrentMemoryContext;
 
   PG_TRY();
   {
@@ -1103,14 +1183,24 @@ static JSValue pljs_find_function(JSContext *ctx, JSValueConst this_val,
   }
   PG_CATCH();
   {
-    StringInfoData str;
-    initStringInfo(&str);
-    appendStringInfo(&str, "javascript function is not found for \"%s\"",
-                     signature);
+    /*
+     * Flush the caught error (see pljs_commit(): five unflushed catches PANIC
+     * the cluster) and surface the real Postgres error.  The old generic
+     * "javascript function is not found" message also hid unrelated failures,
+     * e.g. a permission or syscache error.
+     */
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+    CurrentResourceOwner = m_resowner;
 
     JS_FreeCString(ctx, signature);
 
-    return js_throw(NameStr(str), ctx);
+    return error;
   }
   PG_END_TRY();
 
@@ -1223,6 +1313,7 @@ static JSValue pljs_window_get_partition_local(JSContext *ctx,
   WindowObject winobj = PG_WINDOW_OBJECT();
 
   pljs_window_storage *window_storage;
+  MemoryContext m_mcontext = CurrentMemoryContext;
 
   PG_TRY();
   {
@@ -1231,7 +1322,16 @@ static JSValue pljs_window_get_partition_local(JSContext *ctx,
   }
   PG_CATCH();
   {
-    return js_throw("Unable to retrieve window storage", ctx);
+    /* Flush the caught error; see pljs_commit() for why this is mandatory. */
+    MemoryContextSwitchTo(m_mcontext);
+    ErrorData *edata = CopyErrorData();
+    JSValue error = js_throw_error_data(edata, ctx);
+
+    FlushErrorState();
+    FreeErrorData(edata);
+    MemoryContextSwitchTo(m_mcontext);
+
+    return error;
   }
   PG_END_TRY();
 

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1,5 +1,6 @@
 #include "postgres.h"
 
+#include "access/htup_details.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type_d.h"
@@ -400,6 +401,16 @@ static bool setup_function(FunctionCallInfo fcinfo, HeapTuple proctuple,
   pljs_function->prosrc =
       DatumGetCString(DirectFunctionCall1(textout, prosrcdatum));
 
+  /*
+   * Record which pg_proc tuple this was compiled from.  CREATE OR REPLACE
+   * writes a new tuple version, so a cached entry whose xmin/tid no longer
+   * match the current tuple was compiled from a body that no longer exists.
+   * These two fields were already declared in pljs_func but never written or
+   * read.
+   */
+  pljs_function->fn_xmin = HeapTupleHeaderGetRawXmin(proctuple->t_data);
+  pljs_function->fn_tid = proctuple->t_self;
+
   pg_proc_entry = (Form_pg_proc)GETSTRUCT(proctuple);
 
   // Get the actual name of the procedure.
@@ -772,7 +783,7 @@ Datum pljs_call_handler(PG_FUNCTION_ARGS) {
 
   // First search for a cached copy of the context.
   pljs_function_cache_value *function_entry =
-      pljs_cache_function_find(GetUserId(), fn_oid);
+      pljs_cache_function_find(GetUserId(), fn_oid, proctuple);
 
   if (function_entry) {
     // Make a copy of the function entry to the pljs context.
@@ -1829,7 +1840,7 @@ JSValue pljs_find_js_function(Oid fn_oid, JSContext *ctx) {
   pljs_context context = {0};
 
   pljs_function_cache_value *function_entry =
-      pljs_cache_function_find(GetUserId(), fn_oid);
+      pljs_cache_function_find(GetUserId(), fn_oid, functuple);
 
   if (function_entry != NULL) {
     pljs_function_cache_to_context(&context, function_entry);

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -707,8 +707,20 @@ Datum pljs_call_handler(PG_FUNCTION_ARGS) {
     pljs_cache_function_add(&context);
   }
 
-  ReleaseSysCache(proctuple);
-
+  /*
+   * NB: `proctuple` must stay pinned until we have finished reading from it,
+   * but it MUST be released before we enter JavaScript, because a PROCEDURE
+   * can run COMMIT/ROLLBACK internally and it is illegal to hold a syscache
+   * pin across a transaction boundary (it trips "resource was not closed").
+   *
+   * The original code released the pin up front, before either branch, which
+   * was a use-after-free: the trigger branch still read GETSTRUCT(proctuple)
+   * and the function branch still passed the tuple to
+   * convert_arguments_to_javascript() -> get_func_arg_info().  That only bit
+   * once the entry was actually evicted (cache pressure / concurrent DDL in a
+   * long-running backend).  Release it in each branch at the last safe point
+   * instead: right after the final read, before any JS is executed.
+   */
   if (is_trigger) {
     // Call in the context of a trigger.
     Form_pg_proc procStruct;
@@ -716,11 +728,16 @@ Datum pljs_call_handler(PG_FUNCTION_ARGS) {
     procStruct = (Form_pg_proc)GETSTRUCT(proctuple);
 
     context.function->rettype = procStruct->prorettype;
+
+    ReleaseSysCache(proctuple);
+
     retval = call_trigger(fcinfo, &context);
   } else {
     // Call as a function.
     JSValueConst *argv =
         convert_arguments_to_javascript(fcinfo, proctuple, &context);
+
+    ReleaseSysCache(proctuple);
 
     // Get the old storage object.
     pljs_storage *old_storage = pljs_storage_for_context(context.ctx);

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -822,6 +822,29 @@ Datum pljs_inline_handler(PG_FUNCTION_ARGS) {
  * @returns #Datum of type `VOID`
  */
 Datum pljs_call_validator(PG_FUNCTION_ARGS) {
+  /*
+   * XXX This validator does not actually validate anything, and fixing that is
+   * deliberately left out of this change.
+   *
+   * A language validator is called as validator(oid_of_function_being_created),
+   * so the function to check is the ARGUMENT; fcinfo->flinfo->fn_oid below is
+   * the validator's *own* OID.  Reading prosrc from it fetches the validator's
+   * own pg_proc row, whose prosrc is the C symbol name "pljs_call_validator" --
+   * which happens to parse as a bare JavaScript identifier.  So validation
+   * always succeeds and an invalid body is accepted silently:
+   *
+   *   CREATE FUNCTION f() RETURNS int AS $$ this is ( not js $$ LANGUAGE pljs;
+   *   CREATE FUNCTION
+   *
+   * with the syntax error only surfacing on the first call.
+   *
+   * Simply switching to PG_GETARG_OID(0) is NOT the fix: a pljs body is a
+   * function *body*, not a standalone program -- `return 42;` is a syntax error
+   * at top level -- so the validator has to wrap it the way
+   * pljs_compile_function() does, with the function's argument names, before
+   * compiling.  Without that, correcting the OID rejects almost every valid
+   * function in the suite.  That belongs in its own change with its own tests.
+   */
   Oid fn_oid = fcinfo->flinfo->fn_oid;
   HeapTuple proctuple;
   const char *sourcecode;
@@ -855,16 +878,49 @@ Datum pljs_call_validator(PG_FUNCTION_ARGS) {
   if (JS_IsException(val)) {
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(ctx, &message, &pg_detail);
+
+    /*
+     * dump_error() has copied everything we need into palloc'd memory, so the
+     * JavaScript side can go now.  Without this the whole context leaks on
+     * every rejected function body.
+     */
+    JS_FreeValue(ctx, val);
+    JS_FreeContext(ctx);
+    ReleaseSysCache(proctuple);
+
     pljs_ereport_js_error(message, pg_detail, detail, "execution error");
   }
 
-  // call validator can release the context
+  /*
+   * Drop the compiled function before releasing the context.  JS_FreeContext()
+   * does not free a context that still has live references into it, so leaving
+   * this JSValue alone leaked the entire JSContext -- including all of QuickJS's
+   * intrinsic objects, roughly 68KB measured -- on every single CREATE OR
+   * REPLACE FUNCTION.  A backend doing repeated DDL grew past 500MB and died
+   * with SIGSEGV in seconds.  QuickJS allocates on the libc heap, so none of it
+   * was visible in pg_backend_memory_contexts.
+   */
+  JS_FreeValue(ctx, val);
   JS_FreeContext(ctx);
 
   ReleaseSysCache(proctuple);
 
-  // We also clear the caches.  It is safest to just clear up any instances of
-  // the function or procedure.
+  /*
+   * Clear the caches: the function being created or replaced may already have a
+   * compiled copy cached, and it is now stale.
+   *
+   * This is deliberately still the blanket reset rather than a targeted removal
+   * of this one function.  A cached entry also carries the result-type
+   * information resolved at its first call, and for a RECORD-returning function
+   * that comes from the *call site*, not the function -- so a targeted
+   * invalidation leaves the entry from an earlier call site in place and the
+   * next call converts against the wrong tuple descriptor.  Until the cache key
+   * covers that, the reset is what keeps it correct.
+   *
+   * pljs_cache_reset() now frees the QuickJS side before dropping the Postgres
+   * memory that references it; it previously orphaned every cached JSContext on
+   * the libc heap.
+   */
   pljs_cache_reset();
 
   PG_RETURN_VOID();

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1,6 +1,6 @@
 #include "postgres.h"
 
-#include "catalog/pg_database.h"
+#include "catalog/pg_language.h"
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type_d.h"
 #include "commands/trigger.h"
@@ -700,6 +700,12 @@ Datum pljs_call_handler(PG_FUNCTION_ARGS) {
 
     // If there was a problem creating the function, we'll just return VOID.
     if (JS_IsUndefined(context.js_function)) {
+      /*
+       * This early return bypassed the per-branch ReleaseSysCache() below, so a
+       * function whose body failed to compile leaked the pg_proc pin for the
+       * rest of the transaction.
+       */
+      ReleaseSysCache(proctuple);
       PG_RETURN_VOID();
     }
 
@@ -1539,6 +1545,7 @@ JSValue pljs_find_js_function(Oid fn_oid, JSContext *ctx) {
 
   /* Should not happen? */
   if (!OidIsValid(prolang)) { // NOLINT
+    ReleaseSysCache(functuple);
     return func;
   }
 
@@ -1546,12 +1553,20 @@ JSValue pljs_find_js_function(Oid fn_oid, JSContext *ctx) {
   HeapTuple langtuple =
       SearchSysCache(LANGNAME, NameGetDatum(&langname), 0, 0, 0);
   if (HeapTupleIsValid(langtuple)) {
-    Form_pg_database datForm = (Form_pg_database)GETSTRUCT(langtuple);
-    Oid langtupoid = datForm->oid;
+    /*
+     * This is a pg_language tuple, so it must be read through
+     * Form_pg_language.  It was previously cast to Form_pg_database, which
+     * happened to yield the right answer only because both catalogs begin with
+     * an `Oid oid` at the same offset -- any future field access, or a change to
+     * either catalog's layout, would have read the wrong bytes.
+     */
+    Form_pg_language langForm = (Form_pg_language)GETSTRUCT(langtuple);
+    Oid langtupoid = langForm->oid;
 
     ReleaseSysCache(langtuple);
 
     if (langtupoid != prolang) {
+      ReleaseSysCache(functuple);
       return func;
     }
   }
@@ -1565,6 +1580,16 @@ JSValue pljs_find_js_function(Oid fn_oid, JSContext *ctx) {
     pljs_function_cache_to_context(&context, function_entry);
 
     func = context.js_function;
+
+    /*
+     * The pin was previously released only on the cache-miss branch below, so a
+     * pljs.find_function() that hit the cache -- the common case once a function
+     * has been called once -- held a syscache pin on pg_proc for the rest of the
+     * transaction.  Repeated lookups in one transaction accumulated them, which
+     * is what produces "WARNING: resource was not closed: cache pg_proc ... has
+     * count N" under USE_ASSERT_CHECKING.
+     */
+    ReleaseSysCache(functuple);
   } else {
     pljs_context_cache_value *context_entry =
         pljs_cache_context_find(GetUserId());

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -95,7 +95,20 @@ void _PG_init(void) {
    * (and long before the kernel stack limit) is reached, with a floor so a
    * small max_stack_depth still leaves JS usable.  PostgreSQL's own
    * check_stack_depth() bounds any cumulative C stack consumed across nested
-   * JS<->SQL re-entries, so anchoring the measurement once here is safe.
+   * JS<->SQL re-entries.
+   *
+   * The budget set here is a size, not an anchor: JS_NewRuntime() records the
+   * stack top at this point in _PG_init, which is not where any real JS call
+   * begins.  Each entry into JS therefore calls JS_UpdateStackTop() to
+   * re-anchor the measurement at its own depth -- see the call sites around
+   * each JS_Call().
+   *
+   * Note an asymmetry with pljs.memory_limit below, which does install an
+   * assign hook: max_stack_depth is read once, here, so a later SET
+   * max_stack_depth does not change the JS budget for the life of the backend.
+   * It is a core GUC with no hook available to us, and re-reading it per call
+   * would let one session's SET silently resize a runtime shared with every
+   * other function in the backend.
    */
   {
     long depth_bytes = (long)max_stack_depth * 1024L;
@@ -1134,6 +1147,16 @@ static void call_anonymous_function(const char *source, JSContext *ctx) {
   // generate the function as javascript with all of its arguments
   appendStringInfo(&src, "(function () {%s})();", source);
 
+  /*
+   * Re-anchor QuickJS's stack measurement here, at the C-stack depth this call
+   * actually starts from.  JS_NewRuntime() records the stack top once, inside
+   * _PG_init, at whatever depth the first pljs call happened to be -- but JS
+   * can run far deeper than that (SQL -> JS -> pljs.execute -> SQL -> JS ->
+   * ...), so a budget measured from the original anchor does not describe the
+   * stack this call has left.  The vendored QuickJS exports JS_UpdateStackTop()
+   * for exactly this.
+   */
+  JS_UpdateStackTop(JS_GetRuntime(ctx));
   JS_SetInterruptHandler(JS_GetRuntime(ctx), interrupt_handler, NULL);
 
   JSValue val = JS_Eval(ctx, src.data, strlen(src.data), "<function>", 0);
@@ -1271,6 +1294,16 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
     elog(ERROR, "could not connect to spi manager");
   }
 
+  /*
+   * Re-anchor QuickJS's stack measurement here, at the C-stack depth this call
+   * actually starts from.  JS_NewRuntime() records the stack top once, inside
+   * _PG_init, at whatever depth the first pljs call happened to be -- but JS
+   * can run far deeper than that (SQL -> JS -> pljs.execute -> SQL -> JS ->
+   * ...), so a budget measured from the original anchor does not describe the
+   * stack this call has left.  The vendored QuickJS exports JS_UpdateStackTop()
+   * for exactly this.
+   */
+  JS_UpdateStackTop(JS_GetRuntime(context->ctx));
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
 
   JSValue ret =
@@ -1355,6 +1388,16 @@ static Datum call_function(FunctionCallInfo fcinfo, pljs_context *context,
     elog(ERROR, "could not connect to spi manager");
   }
 
+  /*
+   * Re-anchor QuickJS's stack measurement here, at the C-stack depth this call
+   * actually starts from.  JS_NewRuntime() records the stack top once, inside
+   * _PG_init, at whatever depth the first pljs call happened to be -- but JS
+   * can run far deeper than that (SQL -> JS -> pljs.execute -> SQL -> JS ->
+   * ...), so a budget measured from the original anchor does not describe the
+   * stack this call has left.  The vendored QuickJS exports JS_UpdateStackTop()
+   * for exactly this.
+   */
+  JS_UpdateStackTop(JS_GetRuntime(context->ctx));
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
 
   JSValue ret = JS_Call(context->ctx, context->js_function, JS_UNDEFINED,
@@ -1501,6 +1544,16 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
   // Set the current return context.
   storage->return_state = state;
 
+  /*
+   * Re-anchor QuickJS's stack measurement here, at the C-stack depth this call
+   * actually starts from.  JS_NewRuntime() records the stack top once, inside
+   * _PG_init, at whatever depth the first pljs call happened to be -- but JS
+   * can run far deeper than that (SQL -> JS -> pljs.execute -> SQL -> JS ->
+   * ...), so a budget measured from the original anchor does not describe the
+   * stack this call has left.  The vendored QuickJS exports JS_UpdateStackTop()
+   * for exactly this.
+   */
+  JS_UpdateStackTop(JS_GetRuntime(context->ctx));
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
 
   JSValue ret = JS_Call(context->ctx, context->js_function, JS_UNDEFINED,

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -751,11 +751,38 @@ Datum pljs_call_handler(PG_FUNCTION_ARGS) {
     // Set up a new storage object for this call.
     setup_storage_for_context(&context, fcinfo);
 
-    if (context.function->is_srf) {
-      retval = call_srf_function(fcinfo, &context, argv);
-    } else {
-      retval = call_function(fcinfo, &context, argv);
+    /*
+     * The storage MUST be restored even when the call raises.
+     *
+     * JSContexts are cached per user id and reused for the rest of the session,
+     * and the storage is attached to the context, so a call that raised used to
+     * leave its own storage installed permanently -- pointing at this call's
+     * fcinfo, its return_state and its execution memory context, all of which
+     * are gone once the error has unwound.  The next call of *any* kind that
+     * reads pljs_storage_for_context() -- a trigger, a window function,
+     * return_next() -- then dereferenced that stale pointer and segfaulted the
+     * backend.
+     *
+     * This was latent until a conversion error became reachable from inside a
+     * set-returning function: before that, returning an out-of-range integer
+     * wrapped silently instead of raising, so nothing escaped this block.  A
+     * failing SETOF call followed by any trigger reproduces it within a couple
+     * of dozen iterations.
+     */
+    PG_TRY();
+    {
+      if (context.function->is_srf) {
+        retval = call_srf_function(fcinfo, &context, argv);
+      } else {
+        retval = call_function(fcinfo, &context, argv);
+      }
     }
+    PG_CATCH();
+    {
+      store_storage_in_context(&context, old_storage);
+      PG_RE_THROW();
+    }
+    PG_END_TRY();
 
     // Reset to the old storage now that the call is over.
     store_storage_in_context(&context, old_storage);

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -36,6 +36,8 @@ static Datum call_function(PG_FUNCTION_ARGS, pljs_context *context,
 static Datum call_srf_function(PG_FUNCTION_ARGS, pljs_context *context,
                                JSValueConst *argv);
 
+static void pljs_build_function_source(StringInfoData *src,
+                                       pljs_context *context, bool is_trigger);
 static void call_anonymous_function(const char *, JSContext *);
 static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context);
 static int interrupt_handler(JSRuntime *rt, void *opaque);
@@ -966,104 +968,99 @@ Datum pljs_inline_handler(PG_FUNCTION_ARGS) {
  */
 Datum pljs_call_validator(PG_FUNCTION_ARGS) {
   /*
-   * XXX This validator does not actually validate anything, and fixing that is
-   * deliberately left out of this change.
-   *
    * A language validator is called as validator(oid_of_function_being_created),
-   * so the function to check is the ARGUMENT; fcinfo->flinfo->fn_oid below is
-   * the validator's *own* OID.  Reading prosrc from it fetches the validator's
-   * own pg_proc row, whose prosrc is the C symbol name "pljs_call_validator" --
-   * which happens to parse as a bare JavaScript identifier.  So validation
-   * always succeeds and an invalid body is accepted silently:
+   * so the function to check is the ARGUMENT.  This used to read
+   * fcinfo->flinfo->fn_oid, which is the validator's *own* OID: it fetched the
+   * validator's pg_proc row, whose prosrc is the C symbol name
+   * "pljs_call_validator".  That happens to parse as a bare JavaScript
+   * identifier, so validation always succeeded and an invalid body was accepted
+   * silently --
    *
    *   CREATE FUNCTION f() RETURNS int AS $$ this is ( not js $$ LANGUAGE pljs;
    *   CREATE FUNCTION
    *
-   * with the syntax error only surfacing on the first call.
+   * -- with the syntax error surfacing only on the first call.
    *
-   * Simply switching to PG_GETARG_OID(0) is NOT the fix: a pljs body is a
-   * function *body*, not a standalone program -- `return 42;` is a syntax error
-   * at top level -- so the validator has to wrap it the way
-   * pljs_compile_function() does, with the function's argument names, before
-   * compiling.  Without that, correcting the OID rejects almost every valid
-   * function in the suite.  That belongs in its own change with its own tests.
+   * Correcting the OID is necessary but not sufficient: a pljs body is a function
+   * *body*, not a program, so `return 42;` is a syntax error at top level and
+   * validating the raw prosrc rejects almost every valid function.  It has to be
+   * wrapped the way compilation wraps it, which is why the source builder is
+   * shared with pljs_compile_function().
    */
-  Oid fn_oid = fcinfo->flinfo->fn_oid;
+  Oid fn_oid = PG_GETARG_OID(0);
   HeapTuple proctuple;
-  const char *sourcecode;
-  Datum prosrcdatum;
-  bool isnull;
   JSContext *ctx;
+  pljs_context context = {0};
+  StringInfoData src;
+  bool is_trigger;
 
-  if (fcinfo->flinfo->fn_extra) {
-    elog(DEBUG3, "fn_extra on validate");
+  if (!CheckFunctionValidatorAccess(fcinfo->flinfo->fn_oid, fn_oid)) {
+    PG_RETURN_VOID();
   }
+
+  /* check_function_bodies = off means "create it, do not compile it". */
+  if (!check_function_bodies) {
+    PG_RETURN_VOID();
+  }
+
   proctuple = SearchSysCache(PROCOID, ObjectIdGetDatum(fn_oid), 0, 0, 0);
 
   if (!HeapTupleIsValid(proctuple)) {
     elog(ERROR, "cache lookup failed for function %u", fn_oid);
   }
 
-  prosrcdatum =
-      SysCacheGetAttr(PROCOID, proctuple, Anum_pg_proc_prosrc, &isnull);
-
-  if (isnull) {
-    elog(ERROR, "null prosrc");
-  }
-
-  sourcecode = TextDatumGetCString(prosrcdatum);
+  is_trigger =
+      ((Form_pg_proc)GETSTRUCT(proctuple))->prorettype == TRIGGEROID;
 
   ctx = JS_NewContext(rt);
 
-  JSValue val = JS_Eval(ctx, sourcecode, strlen(sourcecode), "<function>",
+  if (ctx == NULL) {
+    ReleaseSysCache(proctuple);
+    elog(ERROR, "could not create a JavaScript context");
+  }
+
+  context.ctx = ctx;
+
+  /*
+   * Fills in proname, prosrc and the argument names, which the wrapper needs.
+   * Passing NULL fcinfo is the same thing pljs_find_js_function() does.
+   */
+  if (!setup_function(NULL, proctuple, &context)) {
+    JS_FreeContext(ctx);
+    ReleaseSysCache(proctuple);
+    PG_RETURN_VOID();
+  }
+
+  pljs_build_function_source(&src, &context, is_trigger);
+
+  ReleaseSysCache(proctuple);
+
+  JSValue val = JS_Eval(ctx, src.data, strlen(src.data), "<function>",
                         JS_EVAL_FLAG_COMPILE_ONLY);
+
+  pfree(src.data);
 
   if (JS_IsException(val)) {
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(ctx, &message, &pg_detail);
 
     /*
-     * dump_error() has copied everything we need into palloc'd memory, so the
-     * JavaScript side can go now.  Without this the whole context leaks on
-     * every rejected function body.
+     * dump_error() has copied what we need into palloc'd memory, so release the
+     * JavaScript side before reporting.  Without this a rejected body leaked the
+     * whole context: JS_FreeContext() will not free one that still has live
+     * references into it.
      */
     JS_FreeValue(ctx, val);
     JS_FreeContext(ctx);
-    ReleaseSysCache(proctuple);
 
-    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
+    pljs_ereport_js_error(message, pg_detail, detail,
+                          "invalid pljs function body");
   }
 
-  /*
-   * Drop the compiled function before releasing the context.  JS_FreeContext()
-   * does not free a context that still has live references into it, so leaving
-   * this JSValue alone leaked the entire JSContext -- including all of QuickJS's
-   * intrinsic objects, roughly 68KB measured -- on every single CREATE OR
-   * REPLACE FUNCTION.  A backend doing repeated DDL grew past 500MB and died
-   * with SIGSEGV in seconds.  QuickJS allocates on the libc heap, so none of it
-   * was visible in pg_backend_memory_contexts.
-   */
   JS_FreeValue(ctx, val);
   JS_FreeContext(ctx);
 
-  ReleaseSysCache(proctuple);
-
-  /*
-   * Clear the caches: the function being created or replaced may already have a
-   * compiled copy cached, and it is now stale.
-   *
-   * This is deliberately still the blanket reset rather than a targeted removal
-   * of this one function.  A cached entry also carries the result-type
-   * information resolved at its first call, and for a RECORD-returning function
-   * that comes from the *call site*, not the function -- so a targeted
-   * invalidation leaves the entry from an earlier call site in place and the
-   * next call converts against the wrong tuple descriptor.  Until the cache key
-   * covers that, the reset is what keeps it correct.
-   *
-   * pljs_cache_reset() now frees the QuickJS side before dropping the Postgres
-   * memory that references it; it previously orphaned every cached JSContext on
-   * the libc heap.
-   */
+  /* The function is being created or replaced: drop any compiled copy. */
   pljs_cache_reset();
 
   PG_RETURN_VOID();
@@ -1081,14 +1078,27 @@ Datum pljs_call_validator(PG_FUNCTION_ARGS) {
  * or not, this determines arguments
  * @returns #JSValue of the compiled function
  */
-JSValue pljs_compile_function(pljs_context *context, bool is_trigger) {
-  StringInfoData src;
+/*
+ * Build the JavaScript source for a pljs function: its body wrapped in a named
+ * function with the declared argument names, followed by a reference to it so the
+ * evaluation yields the function object.
+ *
+ * Extracted so that pljs_call_validator() can check exactly what
+ * pljs_compile_function() will later compile.  A pljs body is a function *body*,
+ * not a program -- `return 42;` is a syntax error at top level -- so validating
+ * the raw prosrc rejects almost every valid function.  Sharing this makes the two
+ * agree by construction rather than by two copies staying in step.
+ *
+ * The returned StringInfo's data is palloc'd; the caller frees it.
+ */
+static void pljs_build_function_source(StringInfoData *src, pljs_context *context,
+                                       bool is_trigger) {
   int i;
 
-  initStringInfo(&src);
+  initStringInfo(src);
 
   // generate the function as javascript with all of its arguments
-  appendStringInfo(&src, "function %s (", context->function->proname);
+  appendStringInfo(src, "function %s (", context->function->proname);
 
   int inarg = 0;
   for (i = 0; i < context->function->nargs; i++) {
@@ -1097,15 +1107,15 @@ JSValue pljs_compile_function(pljs_context *context, bool is_trigger) {
     }
     // commas between arguments
     if (inarg > 0) {
-      appendStringInfoChar(&src, ',');
+      appendStringInfoChar(src, ',');
     }
 
     // if this is a named argument, append it
     if (context->arguments[i]) {
-      appendStringInfoString(&src, context->arguments[i]);
+      appendStringInfoString(src, context->arguments[i]);
     } else {
       // otherwise append it as an unnamed argument with a number
-      appendStringInfo(&src, "$%d", inarg + 1);
+      appendStringInfo(src, "$%d", inarg + 1);
     }
 
     inarg++;
@@ -1113,33 +1123,40 @@ JSValue pljs_compile_function(pljs_context *context, bool is_trigger) {
 
   // append the other postgres-specific variables as well
   if (context->function->inargs && is_trigger) {
-    appendStringInfo(&src, ", ");
+    appendStringInfo(src, ", ");
   }
 
   if (is_trigger) {
-    appendStringInfo(&src, "NEW, OLD, TG_NAME, TG_WHEN, TG_LEVEL, TG_OP, "
+    appendStringInfo(src, "NEW, OLD, TG_NAME, TG_WHEN, TG_LEVEL, TG_OP, "
                            "TG_RELID, TG_TABLE_NAME, TG_TABLE_SCHEMA, TG_ARGV");
   }
 
-  appendStringInfo(&src, ") {\n%s\n}\n %s;\n", context->function->prosrc,
+  appendStringInfo(src, ") {\n%s\n}\n %s;\n", context->function->prosrc,
                    context->function->proname);
+}
+
+JSValue pljs_compile_function(pljs_context *context, bool is_trigger) {
+  StringInfoData src;
+
+  pljs_build_function_source(&src, context, is_trigger);
 
   JSValue val =
       JS_Eval(context->ctx, src.data, strlen(src.data), "<function>", 0);
 
+  pfree(src.data);
+
   if (!JS_IsException(val)) {
-    pfree(src.data);
-
     return val;
-  } else {
-    char *message = NULL, *pg_detail = NULL;
-    char *detail = dump_error(context->ctx, &message, &pg_detail);
-    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
-
-    return JS_UNDEFINED;
   }
 
-  return val;
+  char *message = NULL, *pg_detail = NULL;
+  char *detail = dump_error(context->ctx, &message, &pg_detail);
+
+  JS_FreeValue(context->ctx, val);
+
+  pljs_ereport_js_error(message, pg_detail, detail, "execution error");
+
+  return JS_UNDEFINED;
 }
 
 /**

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -84,6 +84,11 @@ void _PG_init(void) {
   // Set up the quickjs runtime.
   rt = JS_NewRuntime();
 
+  // Register runtime JS classes (must happen before any JSContext is created,
+  // so every context sees the class; e.g. the prepared-statement handle whose
+  // finalizer reclaims otherwise-leaked SPI plans).
+  pljs_register_js_classes(rt);
+
   // Set up a memory limit if it exists.
   if (configuration.memory_limit) {
     JS_SetMemoryLimit(rt, configuration.memory_limit * 1024 * 1024);

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -8,6 +8,7 @@
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "nodes/parsenodes.h"
+#include "tcop/tcopprot.h"
 #include "utils/builtins.h"
 #include "utils/guc.h"
 #include "utils/lsyscache.h"
@@ -83,6 +84,27 @@ void _PG_init(void) {
 
   // Set up the quickjs runtime.
   rt = JS_NewRuntime();
+
+  /*
+   * Bound the JS call-stack budget explicitly instead of trusting the vendored
+   * JS_DEFAULT_STACK_SIZE.  Without an active limit, unbounded/deep JS
+   * recursion runs the backend's C stack into the ground and crashes the whole
+   * process (SIGSEGV) rather than raising a catchable "stack overflow".  We
+   * size the JS budget to half of the DBA's max_stack_depth so pure-JS
+   * recursion trips QuickJS's guard well before PostgreSQL's own C-stack limit
+   * (and long before the kernel stack limit) is reached, with a floor so a
+   * small max_stack_depth still leaves JS usable.  PostgreSQL's own
+   * check_stack_depth() bounds any cumulative C stack consumed across nested
+   * JS<->SQL re-entries, so anchoring the measurement once here is safe.
+   */
+  {
+    long depth_bytes = (long)max_stack_depth * 1024L;
+    size_t js_stack_size = (size_t)(depth_bytes / 2);
+    if (js_stack_size < 256 * 1024) {
+      js_stack_size = 256 * 1024;
+    }
+    JS_SetMaxStackSize(rt, js_stack_size);
+  }
 
   // Register runtime JS classes (must happen before any JSContext is created,
   // so every context sees the class; e.g. the prepared-statement handle whose

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1396,7 +1396,22 @@ JSValue js_throw_error_data(ErrorData *edata, JSContext *ctx) {
     JS_SetPropertyStr(ctx, error, "hint", JS_NewString(ctx, edata->hint));
   }
 
+  /*
+   * Expose the SQLSTATE under both names.
+   *
+   * The value has always been the five-character string rather than the packed
+   * integer -- unpack_sql_state() is applied here -- but the property was named
+   * `sqlerrcode`, which is PostgreSQL's internal name for the *packed* form.
+   * Every other PL calls it `sqlstate`, and that is the name a JavaScript author
+   * reaches for:
+   *
+   *     catch (e) { if (e.sqlstate === '23505') ... }
+   *
+   * `sqlerrcode` is kept so that existing code keeps working.
+   */
   JS_SetPropertyStr(ctx, error, "sqlerrcode",
+                    JS_NewString(ctx, unpack_sql_state(edata->sqlerrcode)));
+  JS_SetPropertyStr(ctx, error, "sqlstate",
                     JS_NewString(ctx, unpack_sql_state(edata->sqlerrcode)));
 
   return JS_Throw(ctx, error);

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -622,7 +622,19 @@ pljs_storage *pljs_storage_for_context(JSContext *ctx) {
 
   JSValue pljs = JS_GetPropertyStr(ctx, global_obj, "pljs");
 
+  /*
+   * JS_GetOpaque only reads a pointer off the object; it does not keep the
+   * object alive.  Both global_obj and pljs are fresh references returned by
+   * the getters above, so we must drop them here.  The pljs object stays
+   * alive via the global object's property table.  Without this, every call
+   * (and this is a hot path: return_next, window helpers, each function
+   * invocation) leaks a reference and monotonically bumps the singletons'
+   * refcounts for the life of the backend.
+   */
   pljs_storage *storage = JS_GetOpaque(pljs, js_pljs_storage_id);
+
+  JS_FreeValue(ctx, pljs);
+  JS_FreeValue(ctx, global_obj);
 
   return storage;
 }
@@ -667,6 +679,11 @@ static void store_storage_in_context(pljs_context *context,
 
   // Attach storage to the pljs object.
   JS_SetOpaque(pljs, storage);
+
+  // Drop the fresh references returned by the getters above (see
+  // pljs_storage_for_context); the pljs object survives via the global object.
+  JS_FreeValue(context->ctx, pljs);
+  JS_FreeValue(context->ctx, global_obj);
 }
 
 /**

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -37,7 +37,6 @@ static Datum call_srf_function(PG_FUNCTION_ARGS, pljs_context *context,
 
 static void call_anonymous_function(const char *, JSContext *);
 static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context);
-static void signal_handler(int sig_num);
 static int interrupt_handler(JSRuntime *rt, void *opaque);
 static void setup_storage_for_context(pljs_context *context,
                                       FunctionCallInfo fcinfo);
@@ -62,8 +61,6 @@ JSClassID js_pljs_storage_id;
 // class id for pljs window object
 JSClassID js_window_id;
 
-static uint64_t os_pending_signals = 0;
-
 /**
  * @brief PostgreSQL extension initialization function.
  *
@@ -71,9 +68,12 @@ static uint64_t os_pending_signals = 0;
  * runtime.
  */
 void _PG_init(void) {
-  signal(SIGINT, signal_handler);
-  signal(SIGTERM, signal_handler);
-  signal(SIGABRT, signal_handler);
+  // NB: do NOT install our own signal() handlers here.  This runs inside a
+  // backend that has already set up PostgreSQL's own SIGINT/SIGTERM handlers
+  // (query cancel, fast shutdown); overwriting them process-wide broke
+  // statement_timeout / pg_cancel_backend / pg_terminate_backend for the whole
+  // backend for the rest of its life.  Instead, interrupt_handler() consults
+  // PostgreSQL's interrupt flags directly (see below).
 
   // Initialize cache.
   pljs_cache_init();
@@ -293,13 +293,21 @@ pg_noreturn static void pljs_ereport_js_error(const char *message,
   pg_unreachable();
 }
 
-
-static void signal_handler(int sig_num) {
-  os_pending_signals |= ((uint64_t)1 << sig_num);
-}
-
 static int interrupt_handler(JSRuntime *rt, void *opaque) {
-  return (os_pending_signals >> SIGINT) & 1;
+  /*
+   * Return non-zero to make QuickJS abort the running script.  We interrupt on
+   * a pending query cancel (statement_timeout, pg_cancel_backend) or backend
+   * termination (pg_terminate_backend, fast shutdown), read straight from
+   * PostgreSQL's own interrupt flags.
+   *
+   * We deliberately do NOT call CHECK_FOR_INTERRUPTS() here: that would
+   * ereport(ERROR) / siglongjmp out of the middle of the QuickJS interpreter
+   * and leave the runtime in an inconsistent state.  Instead we let QuickJS
+   * unwind cleanly to a JS exception, and each caller runs
+   * CHECK_FOR_INTERRUPTS() once control is back in C to raise the real error
+   * (see the JS_IsException paths below).
+   */
+  return (QueryCancelPending || ProcDiePending) ? 1 : 0;
 }
 
 /**
@@ -1105,13 +1113,19 @@ static void call_anonymous_function(const char *source, JSContext *ctx) {
   appendStringInfo(&src, "(function () {%s})();", source);
 
   JS_SetInterruptHandler(JS_GetRuntime(ctx), interrupt_handler, NULL);
-  os_pending_signals &= ~((uint64_t)1 << SIGINT);
 
   JSValue val = JS_Eval(ctx, src.data, strlen(src.data), "<function>", 0);
 
   if (!JS_IsException(val)) {
     pfree(src.data);
   } else {
+    /*
+     * If QuickJS aborted because a cancel/terminate is pending, raise the real
+     * PostgreSQL error (canceling statement / terminating connection) now that
+     * we are safely back in C, instead of the generic JS interrupt message.
+     */
+    CHECK_FOR_INTERRUPTS();
+
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(ctx, &message, &pg_detail);
     pljs_ereport_js_error(message, pg_detail, detail, "execution error");
@@ -1236,7 +1250,6 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
   }
 
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
-  os_pending_signals &= ~((uint64_t)1 << SIGINT);
 
   JSValue ret =
       JS_Call(context->ctx, context->js_function, JS_UNDEFINED, 10, argv);
@@ -1248,6 +1261,9 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
   SPI_finish();
 
   if (JS_IsException(ret)) {
+    // Surface a pending cancel/terminate as the real PostgreSQL error.
+    CHECK_FOR_INTERRUPTS();
+
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(context->ctx, &message, &pg_detail);
     pljs_ereport_js_error(message, pg_detail, detail, "execution error");
@@ -1318,7 +1334,6 @@ static Datum call_function(FunctionCallInfo fcinfo, pljs_context *context,
   }
 
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
-  os_pending_signals &= ~((uint64_t)1 << SIGINT);
 
   JSValue ret = JS_Call(context->ctx, context->js_function, JS_UNDEFINED,
                         context->function->inargs, argv);
@@ -1330,6 +1345,12 @@ static Datum call_function(FunctionCallInfo fcinfo, pljs_context *context,
     char *error_message = dump_error(context->ctx, &message, &pg_detail);
 
     JS_FreeValue(context->ctx, ret);
+
+    /*
+     * If the exception is really a pending cancel or terminate, raise the proper
+     * PostgreSQL error rather than reporting it as a JavaScript failure.
+     */
+    CHECK_FOR_INTERRUPTS();
 
     pljs_ereport_js_error(message, pg_detail, error_message, "execution error");
 
@@ -1459,7 +1480,6 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
   storage->return_state = state;
 
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
-  os_pending_signals &= ~((uint64_t)1 << SIGINT);
 
   JSValue ret = JS_Call(context->ctx, context->js_function, JS_UNDEFINED,
                         context->function->inargs, argv);
@@ -1467,6 +1487,9 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
   SPI_finish();
 
   if (JS_IsException(ret)) {
+    // Surface a pending cancel/terminate as the real PostgreSQL error.
+    CHECK_FOR_INTERRUPTS();
+
     char *message = NULL, *pg_detail = NULL;
     char *error_message = dump_error(context->ctx, &message, &pg_detail);
 

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -127,7 +127,19 @@ void pljs_guc_init(void) {
  * @param ctx #JSContext - Javascript context with the error
  * @returns @c char * as an error message
  */
-static char *dump_error(JSContext *ctx) {
+/*
+ * Extract the current JavaScript exception.
+ *
+ * Returns a palloc'd string suitable for errdetail(): the stringified error
+ * followed by its stack trace.  When message_out is non-NULL it is set to a
+ * palloc'd copy of the error's own `message` property (or the stringified
+ * throw value for non-Error throws), so callers can surface that as the
+ * primary errmsg() the way plv8 does, instead of a generic "execution error".
+ * Preserving the message here is what lets a coded error (e.g. the "[CODE] "
+ * prefix embedded by the mirror procedures) survive across a nested
+ * pljs.execute()/SPI boundary.
+ */
+static char *dump_error(JSContext *ctx, char **message_out, char **detail_out) {
   JSValue exception_val, val;
   const char *stack;
   const char *str;
@@ -135,12 +147,24 @@ static char *dump_error(JSContext *ctx) {
   char *ret = NULL;
   size_t s1, s2;
 
+  if (message_out) {
+    *message_out = NULL;
+  }
+
+  if (detail_out) {
+    *detail_out = NULL;
+  }
+
   exception_val = JS_GetException(ctx);
 
   /* In the case of OOM, a null exception is thrown. */
   if (JS_IsNull(exception_val)) {
     char *oom = palloc(14);
     strcpy(oom, "out of memory");
+
+    if (message_out) {
+      *message_out = pstrdup("out of memory");
+    }
 
     JS_FreeValue(ctx, exception_val);
 
@@ -153,6 +177,57 @@ static char *dump_error(JSContext *ctx) {
   if (!str) {
     elog(DEBUG3, "error thrown but no error message");
     return NULL;
+  }
+
+  if (detail_out && is_error) {
+    /*
+     * Carry a Postgres detail forward when the error came from a caught SPI
+     * error (see js_throw_error_data): callers surface it as errdetail so the
+     * original explanation survives a nested pljs.execute() re-raise.
+     */
+    JSValue detailval = JS_GetPropertyStr(ctx, exception_val, "detail");
+
+    if (!JS_IsUndefined(detailval)) {
+      const char *detailstr = JS_ToCString(ctx, detailval);
+
+      if (detailstr && detailstr[0]) {
+        *detail_out = pstrdup(detailstr);
+      }
+
+      if (detailstr) {
+        JS_FreeCString(ctx, detailstr);
+      }
+    }
+
+    JS_FreeValue(ctx, detailval);
+  }
+
+  if (message_out) {
+    /*
+     * Prefer the Error's own `message` property; fall back to the stringified
+     * throw value for non-Error throws or a missing/empty message.
+     */
+    if (is_error) {
+      JSValue msgval = JS_GetPropertyStr(ctx, exception_val, "message");
+
+      if (!JS_IsUndefined(msgval)) {
+        const char *msgstr = JS_ToCString(ctx, msgval);
+
+        if (msgstr && msgstr[0]) {
+          *message_out = pstrdup(msgstr);
+        }
+
+        if (msgstr) {
+          JS_FreeCString(ctx, msgstr);
+        }
+      }
+
+      JS_FreeValue(ctx, msgval);
+    }
+
+    if (*message_out == NULL) {
+      *message_out = pstrdup(str);
+    }
   }
 
   if (!is_error) {
@@ -398,8 +473,12 @@ static void setup_start_proc(JSContext *ctx) {
   } else {
     JSValue ret = JS_Call(ctx, func, JS_UNDEFINED, 0, NULL);
     if (JS_IsException(ret)) {
-      ereport(ERROR, (errmsg("start proc execution error"),
-                      errdetail("%s", dump_error(ctx))));
+      char *message = NULL, *pg_detail = NULL;
+      char *detail = dump_error(ctx, &message, &pg_detail);
+      ereport(ERROR,
+              (errmsg("%s", (message && message[0]) ? message
+                                                     : "start proc execution error"),
+               errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
     }
   }
 }
@@ -741,8 +820,11 @@ Datum pljs_call_validator(PG_FUNCTION_ARGS) {
                         JS_EVAL_FLAG_COMPILE_ONLY);
 
   if (JS_IsException(val)) {
+    char *message = NULL, *pg_detail = NULL;
+    char *detail = dump_error(ctx, &message, &pg_detail);
     ereport(ERROR,
-            (errmsg("execution error"), errdetail("%s", dump_error(ctx))));
+            (errmsg("%s", (message && message[0]) ? message : "execution error"),
+             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
   }
 
   // call validator can release the context
@@ -820,8 +902,11 @@ JSValue pljs_compile_function(pljs_context *context, bool is_trigger) {
 
     return val;
   } else {
-    ereport(ERROR, (errmsg("execution error"),
-                    errdetail("%s", dump_error(context->ctx))));
+    char *message = NULL, *pg_detail = NULL;
+    char *detail = dump_error(context->ctx, &message, &pg_detail);
+    ereport(ERROR,
+            (errmsg("%s", (message && message[0]) ? message : "execution error"),
+             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
 
     return JS_UNDEFINED;
   }
@@ -854,9 +939,11 @@ static void call_anonymous_function(const char *source, JSContext *ctx) {
   if (!JS_IsException(val)) {
     pfree(src.data);
   } else {
-
+    char *message = NULL, *pg_detail = NULL;
+    char *detail = dump_error(ctx, &message, &pg_detail);
     ereport(ERROR,
-            (errmsg("execution error"), errdetail("%s", dump_error(ctx))));
+            (errmsg("%s", (message && message[0]) ? message : "execution error"),
+             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
   }
 }
 
@@ -969,8 +1056,11 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
       JS_Call(context->ctx, context->js_function, JS_UNDEFINED, 10, argv);
 
   if (JS_IsException(ret)) {
-    ereport(ERROR, (errmsg("execution error"),
-                    errdetail("%s", dump_error(context->ctx))));
+    char *message = NULL, *pg_detail = NULL;
+    char *detail = dump_error(context->ctx, &message, &pg_detail);
+    ereport(ERROR,
+            (errmsg("%s", (message && message[0]) ? message : "execution error"),
+             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
 
     JS_FreeValue(context->ctx, ret);
 
@@ -1046,11 +1136,14 @@ static Datum call_function(FunctionCallInfo fcinfo, pljs_context *context,
   SPI_finish();
 
   if (JS_IsException(ret)) {
-    char *error_message = dump_error(context->ctx);
+    char *message = NULL, *pg_detail = NULL;
+    char *error_message = dump_error(context->ctx, &message, &pg_detail);
 
     JS_FreeValue(context->ctx, ret);
 
-    ereport(ERROR, (errmsg("execution error"), errdetail("%s", error_message)));
+    ereport(ERROR,
+            (errmsg("%s", (message && message[0]) ? message : "execution error"),
+             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : error_message)));
 
     /* Shuts up the compiler, since ereports of ERROR stop execution. */
     return (Datum)0;
@@ -1171,11 +1264,14 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
   SPI_finish();
 
   if (JS_IsException(ret)) {
-    char *error_message = dump_error(context->ctx);
+    char *message = NULL, *pg_detail = NULL;
+    char *error_message = dump_error(context->ctx, &message, &pg_detail);
 
     JS_FreeValue(context->ctx, ret);
 
-    ereport(ERROR, (errmsg("execution error"), errdetail("%s", error_message)));
+    ereport(ERROR,
+            (errmsg("%s", (message && message[0]) ? message : "execution error"),
+             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : error_message)));
 
     /* Shuts up the compiler, since ereports of ERROR stop execution. */
     return (Datum)0;
@@ -1275,6 +1371,33 @@ JSValue js_throw(const char *message, JSContext *ctx) {
   JSValue error = JS_NewError(ctx);
   JSValue message_value = JS_NewString(ctx, message);
   JS_SetPropertyStr(ctx, error, "message", message_value);
+
+  return JS_Throw(ctx, error);
+}
+
+/*
+ * Like js_throw(), but also attaches the Postgres error's detail, hint and
+ * SQLSTATE to the JS error object (matching plv8).  Used when a Postgres
+ * error caught during SPI execution is surfaced to JavaScript, so the full
+ * error envelope survives into JS and can be re-raised faithfully across a
+ * nested pljs.execute() boundary instead of collapsing to the message alone.
+ */
+JSValue js_throw_error_data(ErrorData *edata, JSContext *ctx) {
+  JSValue error = JS_NewError(ctx);
+
+  JS_SetPropertyStr(ctx, error, "message",
+                    JS_NewString(ctx, edata->message ? edata->message : ""));
+
+  if (edata->detail) {
+    JS_SetPropertyStr(ctx, error, "detail", JS_NewString(ctx, edata->detail));
+  }
+
+  if (edata->hint) {
+    JS_SetPropertyStr(ctx, error, "hint", JS_NewString(ctx, edata->hint));
+  }
+
+  JS_SetPropertyStr(ctx, error, "sqlerrcode",
+                    JS_NewString(ctx, unpack_sql_state(edata->sqlerrcode)));
 
   return JS_Throw(ctx, error);
 }

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1181,11 +1181,32 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
 
   argv[9] = tgargv;
 
+  /*
+   * Connect to SPI, which call_trigger() never did -- so pljs.execute(),
+   * pljs.prepare() and every other SPI entry point failed inside a trigger. Not
+   * just DDL: a bare pljs.execute("SELECT 1") in a BEFORE INSERT trigger failed
+   * too.  Upstream reports it as "execution error"; the error-surfacing work in
+   * this series turns it into the underlying "current transaction is aborted",
+   * which is what made it findable.
+   *
+   * Atomic unconditionally: a trigger has no CallContext, so there is no
+   * nonatomic case to honour, and a trigger must not be able to commit.
+   */
+  if (SPI_connect_ext(0) != SPI_OK_CONNECT) {
+    elog(ERROR, "could not connect to spi manager");
+  }
+
   JS_SetInterruptHandler(JS_GetRuntime(context->ctx), interrupt_handler, NULL);
   os_pending_signals &= ~((uint64_t)1 << SIGINT);
 
   JSValue ret =
       JS_Call(context->ctx, context->js_function, JS_UNDEFINED, 10, argv);
+
+  /*
+   * Before the exception check, as in call_function(): the report below does
+   * not return, so an SPI_finish() after it would never run.
+   */
+  SPI_finish();
 
   if (JS_IsException(ret)) {
     char *message = NULL, *pg_detail = NULL;

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -96,6 +96,23 @@ void _PG_init(void) {
 }
 
 /**
+ * @brief Assign hook for pljs.memory_limit.
+ *
+ * Re-applies the limit to the live QuickJS runtime when the GUC is changed at
+ * runtime (SET pljs.memory_limit = ...).  Without this the GUC value changed
+ * but the interpreter kept whatever limit was installed in _PG_init (the value
+ * present when pljs was first loaded), so a runtime SET silently had no effect
+ * and could not be used to contain a misbehaving function in a running backend.
+ * At initial GUC definition (boot value) rt is still NULL, so this is a no-op
+ * then and _PG_init installs the load-time value explicitly.
+ */
+static void pljs_assign_memory_limit(int newval, void *extra) {
+  if (rt != NULL && newval > 0) {
+    JS_SetMemoryLimit(rt, (size_t)newval * 1024 * 1024);
+  }
+}
+
+/**
  * @brief Set up the GUCs.
  *
  * Sets up the GUCs that help define the behavior of the interpreter.
@@ -115,7 +132,7 @@ void pljs_guc_init(void) {
                           gettext_noop("Runtime limit in MBytes"),
                           gettext_noop("The default value is 512 MB"),
                           (int *)&configuration.memory_limit, 512, 64, 3096,
-                          PGC_SUSET, 0, NULL, NULL, NULL);
+                          PGC_SUSET, 0, NULL, pljs_assign_memory_limit, NULL);
 
   DefineCustomStringVariable(
       "pljs.start_proc",

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -253,6 +253,25 @@ static char *dump_error(JSContext *ctx, char **message_out, char **detail_out) {
   return ret;
 }
 
+/*
+ * Report a JavaScript exception as a PostgreSQL error.
+ *
+ * `message` and `detail` are dump_error()'s out-parameters; `fallback` is used when
+ * the exception carried no message of its own, which is why the empty-string check
+ * matters and why it lives in one place rather than at every report site.
+ *
+ * Does not return.
+ */
+pg_noreturn static void pljs_ereport_js_error(const char *message,
+                                             const char *pg_detail,
+                                             const char *detail,
+                                             const char *fallback) {
+  ereport(ERROR, (errmsg("%s", (message && message[0]) ? message : fallback),
+                  errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
+  pg_unreachable();
+}
+
+
 static void signal_handler(int sig_num) {
   os_pending_signals |= ((uint64_t)1 << sig_num);
 }
@@ -475,10 +494,7 @@ static void setup_start_proc(JSContext *ctx) {
     if (JS_IsException(ret)) {
       char *message = NULL, *pg_detail = NULL;
       char *detail = dump_error(ctx, &message, &pg_detail);
-      ereport(ERROR,
-              (errmsg("%s", (message && message[0]) ? message
-                                                     : "start proc execution error"),
-               errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
+      pljs_ereport_js_error(message, pg_detail, detail, "start proc execution error");
     }
   }
 }
@@ -822,9 +838,7 @@ Datum pljs_call_validator(PG_FUNCTION_ARGS) {
   if (JS_IsException(val)) {
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(ctx, &message, &pg_detail);
-    ereport(ERROR,
-            (errmsg("%s", (message && message[0]) ? message : "execution error"),
-             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
+    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
   }
 
   // call validator can release the context
@@ -904,9 +918,7 @@ JSValue pljs_compile_function(pljs_context *context, bool is_trigger) {
   } else {
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(context->ctx, &message, &pg_detail);
-    ereport(ERROR,
-            (errmsg("%s", (message && message[0]) ? message : "execution error"),
-             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
+    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
 
     return JS_UNDEFINED;
   }
@@ -941,9 +953,7 @@ static void call_anonymous_function(const char *source, JSContext *ctx) {
   } else {
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(ctx, &message, &pg_detail);
-    ereport(ERROR,
-            (errmsg("%s", (message && message[0]) ? message : "execution error"),
-             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
+    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
   }
 }
 
@@ -1058,9 +1068,7 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
   if (JS_IsException(ret)) {
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(context->ctx, &message, &pg_detail);
-    ereport(ERROR,
-            (errmsg("%s", (message && message[0]) ? message : "execution error"),
-             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : detail)));
+    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
 
     JS_FreeValue(context->ctx, ret);
 
@@ -1141,9 +1149,7 @@ static Datum call_function(FunctionCallInfo fcinfo, pljs_context *context,
 
     JS_FreeValue(context->ctx, ret);
 
-    ereport(ERROR,
-            (errmsg("%s", (message && message[0]) ? message : "execution error"),
-             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : error_message)));
+    pljs_ereport_js_error(message, pg_detail, error_message, "execution error");
 
     /* Shuts up the compiler, since ereports of ERROR stop execution. */
     return (Datum)0;
@@ -1269,9 +1275,7 @@ static Datum call_srf_function(FunctionCallInfo fcinfo, pljs_context *context,
 
     JS_FreeValue(context->ctx, ret);
 
-    ereport(ERROR,
-            (errmsg("%s", (message && message[0]) ? message : "execution error"),
-             errdetail("%s", (pg_detail && pg_detail[0]) ? pg_detail : error_message)));
+    pljs_ereport_js_error(message, pg_detail, error_message, "execution error");
 
     /* Shuts up the compiler, since ereports of ERROR stop execution. */
     return (Datum)0;

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -494,8 +494,24 @@ static void setup_start_proc(JSContext *ctx) {
     if (JS_IsException(ret)) {
       char *message = NULL, *pg_detail = NULL;
       char *detail = dump_error(ctx, &message, &pg_detail);
+
+      /*
+       * Release the JavaScript side before reporting: the report does not
+       * return, so anything freed after it is never freed at all.
+       */
+      JS_FreeValue(ctx, ret);
+      JS_FreeValue(ctx, func);
+
       pljs_ereport_js_error(message, pg_detail, detail, "start proc execution error");
     }
+
+    /*
+     * The function reference and the call's result both belong to this function.
+     * Neither was released, so every context creation with pljs.start_proc set
+     * leaked both.
+     */
+    JS_FreeValue(ctx, ret);
+    JS_FreeValue(ctx, func);
   }
 }
 
@@ -1606,7 +1622,16 @@ JSValue pljs_find_js_function(Oid fn_oid, JSContext *ctx) {
   if (function_entry != NULL) {
     pljs_function_cache_to_context(&context, function_entry);
 
-    func = context.js_function;
+    /*
+     * Hand out a reference we own.  pljs_function_cache_to_context() borrows the
+     * cache's, and the cache entry is that value's only owner -- but a JSValue
+     * returned from a C function belongs to its caller, so pljs.find_function()
+     * handed JavaScript a reference it had not counted.  The engine dropped it
+     * when the JS variable died, and after enough lookups the refcount reached
+     * zero while the entry was still cached, leaving the cache holding a freed
+     * object.  The next call through it terminated the backend.
+     */
+    func = JS_DupValue(context.ctx, context.js_function);
 
     /*
      * The pin was previously released only on the cache-miss branch below, so a

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1158,7 +1158,22 @@ static Datum call_function(FunctionCallInfo fcinfo, pljs_context *context,
 
     if (rettype == RECORDOID) {
       TupleDesc tupdesc;
-      get_call_result_type(fcinfo, &rettype, &tupdesc);
+
+      /*
+       * Check the status rather than discarding it.  TYPEFUNC_RECORD means the
+       * caller did not supply a column definition list, and tupdesc comes back
+       * NULL; pljs_jsvalue_to_record() then reached
+       * lookup_rowtype_tupdesc(RECORDOID, -1) and raised "record type has not
+       * been registered", which is an unhelpful way to say "you forgot
+       * AS (a int, b text)".
+       */
+      if (get_call_result_type(fcinfo, &rettype, &tupdesc) != TYPEFUNC_COMPOSITE) {
+        ereport(ERROR,
+                (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                 errmsg("a function returning \"record\" needs a column "
+                        "definition list"),
+                 errhint("Call it as ... AS (column_name data_type, ...).")));
+      }
 
       pljs_type type;
       pljs_type_fill(&type, rettype);

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -342,7 +342,19 @@ static int interrupt_handler(JSRuntime *rt, void *opaque) {
    * CHECK_FOR_INTERRUPTS() once control is back in C to raise the real error
    * (see the JS_IsException paths below).
    */
-  return (QueryCancelPending || ProcDiePending) ? 1 : 0;
+  /*
+   * QueryCancelPending and ProcDiePending are the two that matter most, and are
+   * kept as an explicit fast path.  InterruptPending then catches everything else
+   * PostgreSQL considers worth interrupting for -- ClientConnectionLost, recovery
+   * conflicts, IdleInTransactionSessionTimeoutPending -- so a runaway script
+   * unwinds for those too rather than spinning until one of the first two happens
+   * to be set.
+   *
+   * A spurious wake-up is harmless: the caller runs CHECK_FOR_INTERRUPTS() once
+   * control is back in C, and if nothing is actually pending that is a no-op and
+   * the JavaScript exception is reported normally.
+   */
+  return (QueryCancelPending || ProcDiePending || InterruptPending) ? 1 : 0;
 }
 
 /**
@@ -1165,14 +1177,25 @@ static void call_anonymous_function(const char *source, JSContext *ctx) {
     pfree(src.data);
   } else {
     /*
+     * Extract the error, release everything, then report.  The report never
+     * returns, so anything freed after it is dead code -- and `val` was never
+     * released on this path at all, leaking a QuickJS reference for every failed
+     * DO block.
+     */
+    char *message = NULL, *pg_detail = NULL;
+    char *detail = dump_error(ctx, &message, &pg_detail);
+
+    JS_FreeValue(ctx, val);
+    pfree(src.data);
+
+    /*
      * If QuickJS aborted because a cancel/terminate is pending, raise the real
      * PostgreSQL error (canceling statement / terminating connection) now that
      * we are safely back in C, instead of the generic JS interrupt message.
+     * After the cleanup above, so a cancel cannot skip it.
      */
     CHECK_FOR_INTERRUPTS();
 
-    char *message = NULL, *pg_detail = NULL;
-    char *detail = dump_error(ctx, &message, &pg_detail);
     pljs_ereport_js_error(message, pg_detail, detail, "execution error");
   }
 }
@@ -1316,17 +1339,22 @@ static Datum call_trigger(FunctionCallInfo fcinfo, pljs_context *context) {
   SPI_finish();
 
   if (JS_IsException(ret)) {
-    // Surface a pending cancel/terminate as the real PostgreSQL error.
-    CHECK_FOR_INTERRUPTS();
-
+    /*
+     * Same order as call_function(): extract, release, then report.  The
+     * JS_FreeValue() below used to sit *after* the report, which never returns,
+     * so it was dead code -- `ret` leaked a QuickJS reference on every trigger
+     * exception, not merely on a cancel.
+     */
     char *message = NULL, *pg_detail = NULL;
     char *detail = dump_error(context->ctx, &message, &pg_detail);
-    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
 
     JS_FreeValue(context->ctx, ret);
-
     MemoryContextSwitchTo(old_context);
-    PG_RETURN_VOID();
+
+    /* Surface a pending cancel/terminate as the real PostgreSQL error. */
+    CHECK_FOR_INTERRUPTS();
+
+    pljs_ereport_js_error(message, pg_detail, detail, "execution error");
   }
 
   if (JS_IsNull(ret) || !TRIGGER_FIRED_FOR_ROW(event)) {

--- a/src/pljs.c
+++ b/src/pljs.c
@@ -1060,8 +1060,17 @@ Datum pljs_call_validator(PG_FUNCTION_ARGS) {
   JS_FreeValue(ctx, val);
   JS_FreeContext(ctx);
 
-  /* The function is being created or replaced: drop any compiled copy. */
-  pljs_cache_reset();
+  /*
+   * The function is being created or replaced, so drop the compiled copy cached
+   * for it -- just that entry, in every user's cache.
+   *
+   * This was previously a blanket pljs_cache_reset(), which destroys every
+   * per-user JSContext and rebuilds it on the next call.  JS_FreeContext() will
+   * not free a context that still has live references into it, so the old one was
+   * not necessarily reclaimed and a backend doing repeated DDL grew without
+   * bound.
+   */
+  pljs_cache_function_remove(fn_oid);
 
   PG_RETURN_VOID();
 }

--- a/src/pljs.h
+++ b/src/pljs.h
@@ -159,6 +159,10 @@ void _PG_init(void);
 void pljs_guc_init(void);
 void pljs_cache_init(void);
 void pljs_setup_namespace(JSContext *ctx);
+// Registers runtime JS classes (e.g. the prepared-statement handle whose GC
+// finalizer reclaims the SPI plan).  Must run once, after the runtime exists
+// and before any JSContext is created.
+void pljs_register_js_classes(JSRuntime *rt);
 
 // Throw a Javascript error
 JSValue js_throw(const char *, JSContext *);

--- a/src/pljs.h
+++ b/src/pljs.h
@@ -185,6 +185,7 @@ pljs_context_cache_value *pljs_cache_context_find(Oid user_id);
 // Functions
 pljs_function_cache_value *pljs_cache_function_find(Oid user_id, Oid fn_oid);
 void pljs_cache_function_add(pljs_context *context);
+void pljs_cache_function_remove(Oid fn_oid);
 
 // Serialization and Deserialization
 void pljs_function_cache_to_context(pljs_context *,

--- a/src/pljs.h
+++ b/src/pljs.h
@@ -17,6 +17,15 @@
 #include "deps/quickjs/quickjs-libc.h"
 #include "deps/quickjs/quickjs.h"
 
+/*
+ * PostgreSQL 18 provides pg_noreturn (C11 _Noreturn); earlier versions provide
+ * only pg_attribute_noreturn().  GNU attributes may also precede the declaration
+ * specifiers, so one spelling works on every supported version.
+ */
+#ifndef pg_noreturn
+#define pg_noreturn pg_attribute_noreturn()
+#endif
+
 #define STORAGE_HASH_LEN 32
 #ifndef PLJS_VERSION
 #define PLJS_VERSION "unknown"

--- a/src/pljs.h
+++ b/src/pljs.h
@@ -214,7 +214,9 @@ Datum *pljs_jsvalue_to_datums(pljs_type *type, JSValue val, bool **is_null,
 uint32_t pljs_js_array_length(JSValue, JSContext *);
 void pljs_type_fill(pljs_type *, Oid);
 bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
-                                                   TupleDesc tupdesc);
+                                                   TupleDesc tupdesc,
+                                                   char **missing_colname,
+                                                   char **provided_keys);
 JSValue pljs_values_to_array(JSValue *, int, int, JSContext *);
 void pljs_variable_param_setup(ParseState *, void *);
 ParamListInfo pljs_setup_variable_paramlist(pljs_param_state *, Datum *,

--- a/src/pljs.h
+++ b/src/pljs.h
@@ -153,6 +153,8 @@ void pljs_setup_namespace(JSContext *ctx);
 
 // Throw a Javascript error
 JSValue js_throw(const char *, JSContext *);
+// Throw a Javascript error carrying a Postgres ErrorData's detail/hint/sqlstate
+JSValue js_throw_error_data(ErrorData *, JSContext *);
 
 // Functions
 JSValue pljs_compile_function(pljs_context *context, bool is_trigger);

--- a/src/pljs.h
+++ b/src/pljs.h
@@ -66,6 +66,14 @@ typedef struct pljs_function_cache_value {
   char argmodes[FUNC_MAX_ARGS];
   char *prosrc;
   TypeFuncClass typeclass;
+
+  /*
+   * Identity of the pg_proc tuple this entry was compiled from, so a stale
+   * entry can be recognised.  Same mechanism plpgsql uses (see
+   * plpgsql_compile()).
+   */
+  TransactionId fn_xmin;
+  ItemPointerData fn_tid;
 } pljs_function_cache_value;
 
 typedef struct pljs_param_state {
@@ -183,7 +191,8 @@ void pljs_cache_context_remove(Oid);
 pljs_context_cache_value *pljs_cache_context_find(Oid user_id);
 
 // Functions
-pljs_function_cache_value *pljs_cache_function_find(Oid user_id, Oid fn_oid);
+pljs_function_cache_value *pljs_cache_function_find(Oid user_id, Oid fn_oid,
+                                                    HeapTuple proctuple);
 void pljs_cache_function_add(pljs_context *context);
 void pljs_cache_function_remove(Oid fn_oid);
 

--- a/src/types.c
+++ b/src/types.c
@@ -647,9 +647,19 @@ Datum pljs_jsvalue_to_array(pljs_type *type, JSValue val, JSContext *ctx,
  * @returns @c bool
  */
 bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
-                                                   TupleDesc tupdesc) {
+                                                   TupleDesc tupdesc,
+                                                   char **missing_colname,
+                                                   char **provided_keys) {
   uint32_t object_keys_length = 0;
   JSPropertyEnum *tab;
+
+  if (missing_colname != NULL) {
+    *missing_colname = NULL;
+  }
+
+  if (provided_keys != NULL) {
+    *provided_keys = NULL;
+  }
 
   if (JS_GetOwnPropertyNames(ctx, &tab, &object_keys_length, val,
                              JS_GPN_STRING_MASK) < 0) {
@@ -669,7 +679,7 @@ bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
          object_key++) {
       const char *atom = JS_AtomToCString(ctx, tab[object_key].atom);
 
-      if (strcmp(colname, atom) == 0) {
+      if (atom != NULL && strcmp(colname, atom) == 0) {
         found = true;
         JS_FreeCString(ctx, atom);
         break;
@@ -679,6 +689,41 @@ bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
     }
 
     if (!found) {
+      /*
+       * Report which column is missing, and what the object did offer, so the
+       * caller can raise something actionable.  The bare "field name / property
+       * name mismatch" left the author to guess, and the usual cause is a case
+       * difference: JavaScript property names are case sensitive while
+       * PostgreSQL folds unquoted identifiers to lower case.
+       */
+      if (missing_colname != NULL) {
+        *missing_colname = pstrdup(colname);
+      }
+
+      if (provided_keys != NULL) {
+        StringInfoData keys;
+
+        initStringInfo(&keys);
+
+        for (uint32_t object_key = 0; object_key < object_keys_length;
+             object_key++) {
+          const char *atom = JS_AtomToCString(ctx, tab[object_key].atom);
+
+          if (atom == NULL) {
+            continue;
+          }
+
+          if (keys.len > 0) {
+            appendStringInfoString(&keys, ", ");
+          }
+
+          appendStringInfoString(&keys, atom);
+          JS_FreeCString(ctx, atom);
+        }
+
+        *provided_keys = keys.data;
+      }
+
       return false;
     }
   }

--- a/src/types.c
+++ b/src/types.c
@@ -19,6 +19,7 @@
 #include "pljs.h"
 
 #include <string.h>
+#include <time.h>
 
 /*
  * Error handling helper macros for consistent error patterns.
@@ -418,9 +419,11 @@ static JSValue pljs_datum_to_jsvalue_fallback(Datum arg, pljs_type type,
   } else {
     // If this is a variable length type, make a copy of it.
     if (type.length == -1) {
-      ret = JS_NewStringLen(ctx, (char *)VARDATA(arg), VARSIZE_ANY_EXHDR(arg));
+      struct varlena *vl = (struct varlena *)DatumGetPointer(arg);
+
+      ret = JS_NewStringLen(ctx, VARDATA(vl), VARSIZE_ANY_EXHDR(vl));
       JS_SetPropertyStr(ctx, ret, "length",
-                        JS_NewInt32(ctx, VARSIZE_ANY_EXHDR(arg)));
+                        JS_NewInt32(ctx, VARSIZE_ANY_EXHDR(vl)));
     } else {
       ret = JS_NewStringLen(ctx, (char *)arg, type.length);
       JS_SetPropertyStr(ctx, ret, "length", JS_NewInt32(ctx, type.length));

--- a/src/types.c
+++ b/src/types.c
@@ -945,6 +945,28 @@ static Datum pljs_jsvalue_to_datum_fallback(JSValue value, bool *is_null,
   return ret;
 }
 
+/*
+ * Return a SQL NULL from a conversion without touching fcinfo.
+ *
+ * PG_RETURN_NULL() expands to `fcinfo->isnull = true; return (Datum) 0`, so it
+ * only works where fcinfo is real.  pljs_jsvalue_to_datum() is also called for
+ * every column of a composite -- from pljs_jsvalue_to_datums() and
+ * pljs_jsvalue_to_record() -- and both of those pass fcinfo == NULL, reporting
+ * the null through the is_null argument instead.  Using PG_RETURN_NULL() on
+ * those paths writes through a null pointer.
+ */
+static inline Datum pljs_null_datum(bool *is_null, FunctionCallInfo fcinfo) {
+  if (is_null != NULL) {
+    *is_null = true;
+  }
+
+  if (fcinfo != NULL) {
+    fcinfo->isnull = true;
+  }
+
+  return (Datum)0;
+}
+
 /**
  * @brief Converts a Javascript value to a Postgres #Datum.
  *
@@ -983,15 +1005,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
   }
 
   if (JS_IsNull(val) || JS_IsUndefined(val)) {
-    if (fcinfo) {
-      PG_RETURN_NULL();
-    } else {
-      if (is_null) {
-        *is_null = true;
-      }
-
-      PG_RETURN_NULL();
-    }
+    return pljs_null_datum(is_null, fcinfo);
   }
 
   switch (rettype) {
@@ -1256,7 +1270,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
         }
       }
 
-      PG_RETURN_NULL();
+      return pljs_null_datum(is_null, fcinfo);
     }
   }
 
@@ -1280,8 +1294,20 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
     return pljs_jsvalue_to_datum_fallback(val, is_null, type, ctx);
   }
 
-  // shut up, compiler
-  PG_RETURN_NULL();
+  /*
+   * Reached when a case matched the type but not the value -- DATEOID,
+   * TIMESTAMPOID and TIMESTAMPTZOID each handle only a JavaScript Date and
+   * break out of the switch for anything else.  A plain string for a date
+   * column lands here, so this is an ordinary path and not just a sop to the
+   * compiler.
+   *
+   * NB: it yields SQL NULL, which means a perfectly valid date *string* is
+   * silently dropped rather than parsed through the type's input function.
+   * That is the pre-existing behaviour of the scalar path and changing it is a
+   * separate question from not crashing; this commit only stops the write
+   * through a null fcinfo.
+   */
+  return pljs_null_datum(is_null, fcinfo);
 }
 
 /**

--- a/src/types.c
+++ b/src/types.c
@@ -702,12 +702,29 @@ bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
 
       if (provided_keys != NULL) {
         StringInfoData keys;
+        uint32_t listed = 0;
+
+        /*
+         * Cap the list.  An object with ten thousand properties would otherwise
+         * produce a ten-thousand-name error message, which goes to the server
+         * log as well as to the client.  Ten names plus the total is enough to
+         * diagnose a typo, which is what this message is for.
+         */
+        const uint32_t max_listed = 10;
 
         initStringInfo(&keys);
 
         for (uint32_t object_key = 0; object_key < object_keys_length;
              object_key++) {
-          const char *atom = JS_AtomToCString(ctx, tab[object_key].atom);
+          const char *atom;
+
+          if (listed >= max_listed) {
+            appendStringInfo(&keys, ", ... (%u properties in total)",
+                             object_keys_length);
+            break;
+          }
+
+          atom = JS_AtomToCString(ctx, tab[object_key].atom);
 
           if (atom == NULL) {
             continue;
@@ -719,6 +736,7 @@ bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
 
           appendStringInfoString(&keys, atom);
           JS_FreeCString(ctx, atom);
+          listed++;
         }
 
         *provided_keys = keys.data;

--- a/src/types.c
+++ b/src/types.c
@@ -1003,6 +1003,63 @@ static inline Datum pljs_null_datum(bool *is_null, FunctionCallInfo fcinfo) {
 }
 
 /**
+ * @brief Converts a JavaScript string into a #Datum through the target type's
+ * text input function.
+ *
+ * The input function parses the full decimal text exactly, and raises on
+ * malformed or out-of-range input.  That is the only correct way to turn a
+ * *string* into a numeric datum: QuickJS's numeric coercion
+ * (JS_ToInt32/JS_ToInt64/JS_ToFloat64) goes through an IEEE-754 double, which
+ * silently loses precision above 2^53 -- "9223372036854775807" arrives as
+ * INT64_MIN, and "123456789012345678" lands two off.
+ *
+ * It is also what plv8 does, so a procedure that binds a numeric string behaves
+ * the same on both.
+ *
+ * @param typid #Oid - target type
+ * @param val #JSValue - the JavaScript string to parse
+ * @param ctx #JSContext - Javascript context to execute in
+ * @returns #Datum parsed from the string
+ */
+static Datum pljs_string_to_datum_via_input(Oid typid, JSValueConst val,
+                                            JSContext *ctx) {
+  size_t plen;
+  const char *str = JS_ToCStringLen(ctx, &plen, val);
+  Oid typinput, typioparam;
+  Datum ret;
+
+  if (str == NULL) {
+    elog(ERROR, "could not convert JavaScript value to a string");
+  }
+
+  if (memchr(str, '\0', plen) != NULL) {
+    JS_FreeCString(ctx, str);
+    ereport(ERROR,
+            (errcode(ERRCODE_UNTRANSLATABLE_CHARACTER),
+             errmsg("null byte (\\u0000) is not allowed in a value of type %s",
+                    format_type_be(typid))));
+  }
+
+  getTypeInputInfo(typid, &typinput, &typioparam);
+
+  PG_TRY();
+  {
+    ret = OidInputFunctionCall(typinput, (char *)str, typioparam, -1);
+  }
+  PG_CATCH();
+  {
+    /* Do not leak the QuickJS C-string when the input function rejects it. */
+    JS_FreeCString(ctx, str);
+    PG_RE_THROW();
+  }
+  PG_END_TRY();
+
+  JS_FreeCString(ctx, str);
+
+  return ret;
+}
+
+/**
  * @brief Converts a Javascript value to a Postgres #Datum.
  *
  * Takes a Javascript value and converts it into a Postgres #Datum,
@@ -1064,6 +1121,12 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
 
   case INT2OID: {
     int32_t in;
+
+    /* A string carries exact decimal text; parse it, do not go via a double. */
+    if (JS_IsString(val)) {
+      return pljs_string_to_datum_via_input(INT2OID, val, ctx);
+    }
+
     if (JS_IsBigInt(ctx, val)) {
       int64_t big_in;
 
@@ -1080,6 +1143,11 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
 
   case INT4OID: {
     int32_t in;
+
+    if (JS_IsString(val)) {
+      return pljs_string_to_datum_via_input(INT4OID, val, ctx);
+    }
+
     if (JS_IsBigInt(ctx, val)) {
       int64_t big_in;
 
@@ -1096,6 +1164,11 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
 
   case INT8OID: {
     int64_t in;
+
+    if (JS_IsString(val)) {
+      return pljs_string_to_datum_via_input(INT8OID, val, ctx);
+    }
+
     if (JS_IsBigInt(ctx, val)) {
       JS_ToBigInt64(ctx, &in, val);
     } else {
@@ -1123,6 +1196,16 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
   }
 
   case NUMERICOID: {
+    /*
+     * A string carries exact decimal text, including a scale no double can
+     * represent, so parse it with numeric's input function rather than routing
+     * it through float8: "12345678901234567890.123456789" came back as
+     * 12345678901234600000.
+     */
+    if (JS_IsString(val)) {
+      return pljs_string_to_datum_via_input(NUMERICOID, val, ctx);
+    }
+
     if (JS_IsBigInt(ctx, val)) {
       // Convert the value to a string then convert it to NUMERIC.
       JSValue str = JS_ToString(ctx, val);

--- a/src/types.c
+++ b/src/types.c
@@ -666,6 +666,8 @@ bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
     return false;
   }
 
+  bool result = true;
+
   for (int16 c = 0; c < tupdesc->natts; c++) {
     if (TupleDescAttr(tupdesc, c)->attisdropped) {
       continue;
@@ -743,10 +745,26 @@ bool pljs_jsvalue_object_contains_all_column_names(JSValue val, JSContext *ctx,
       }
 
       return false;
+
+      result = false;
+      break;
     }
   }
 
-  return true;
+  /*
+   * JS_GetOwnPropertyNames() returns a js_malloc'd table plus one owned atom
+   * reference per entry; both must be released.  Otherwise every call -- e.g.
+   * every RETURNS TABLE / SETOF composite return_next() -- leaks the table
+   * (which counts against the QuickJS runtime memory limit) and an atom
+   * reference per property, and neither is reclaimed until the backend exits.
+   * A long-running backend therefore slowly exhausts pljs.memory_limit.
+   */
+  for (uint32_t i = 0; i < object_keys_length; i++) {
+    JS_FreeAtom(ctx, tab[i].atom);
+  }
+  js_free(ctx, tab);
+
+  return result;
 }
 
 /**
@@ -1803,6 +1821,19 @@ static JsonbValue *jsonb_object_from_object(JSValue object,
     // Free up the memory.
     JS_FreeValue(ctx, o);
   }
+
+  /*
+   * Release the property-name table and its atom references handed back by
+   * JS_GetOwnPropertyNames().  The key C-strings are freed by jsonb_from_value()
+   * (WJB_KEY), but the table itself is js_malloc'd and each tab[i].atom is an
+   * owned reference; leaking them grows the QuickJS runtime heap on every
+   * JS-object -> jsonb conversion (a very hot path for functions returning
+   * jsonb), eventually tripping pljs.memory_limit in a long-running backend.
+   */
+  for (uint32_t object_key = 0; object_key < object_keys_length; object_key++) {
+    JS_FreeAtom(ctx, tab[object_key].atom);
+  }
+  js_free(ctx, tab);
 
   // Push that we are at the end of an object.
   value = jsonb_push(pstate, WJB_END_OBJECT, NULL);

--- a/src/types.c
+++ b/src/types.c
@@ -1226,10 +1226,43 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
     break;
   }
 
+  case NAMEOID: {
+    /*
+     * `name` is a fixed-length NameData -- NAMEDATALEN bytes, no varlena header
+     * -- so it cannot be built the way text/varchar/bpchar are below. Doing that
+     * writes a varlena length word into the first bytes of the name, and every
+     * comparison against a real name then reads that as characters: a catalog
+     * lookup by nspname, relname or typname matches nothing at all, silently.
+     * namein() lays the value out correctly and applies the truncation rule for
+     * anything longer than NAMEDATALEN - 1.
+     */
+    const char *str = JS_ToCString(ctx, val);
+    Datum ret;
+
+    if (str == NULL) {
+      elog(ERROR, "could not convert JavaScript value to a string");
+    }
+
+    PG_TRY();
+    {
+      ret = DirectFunctionCall1(namein, CStringGetDatum(str));
+    }
+    PG_CATCH();
+    {
+      /* Do not leak the QuickJS C-string if namein() rejects the value. */
+      JS_FreeCString(ctx, str);
+      PG_RE_THROW();
+    }
+    PG_END_TRY();
+
+    JS_FreeCString(ctx, str);
+
+    return ret;
+  }
+
   case TEXTOID:
   case VARCHAROID:
   case BPCHAROID:
-  case NAMEOID:
   case XMLOID: {
     size_t plen;
     const char *str = JS_ToCStringLen(ctx, &plen, val);

--- a/src/types.c
+++ b/src/types.c
@@ -1147,7 +1147,7 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
 
       uint32_t *array_copy = palloc(pbytes_per_element * length);
 
-      for (size_t i = 0; i < pbytes_per_element * length; i++) {
+      for (size_t i = 0; i < length; i++) {
         int32_t in;
 
         JSValue jsval = JS_GetPropertyUint32(ctx, val, i);

--- a/src/types.c
+++ b/src/types.c
@@ -813,8 +813,19 @@ Datum *pljs_jsvalue_to_datums(pljs_type *type, JSValue val, bool **is_null,
 
     JSValue o = JS_GetPropertyStr(ctx, val, colname);
 
+    /*
+     * JS_GetPropertyStr() returns an owned reference, so it has to be released
+     * on every path out of this iteration -- including the null/undefined
+     * short-circuit below.  Leaking it costs one QuickJS reference per column
+     * per row, on every composite return and every return_next() of a row
+     * object, which is the hottest allocation path in the extension.  Because
+     * QuickJS runs on the libc allocator the loss is invisible to
+     * pg_backend_memory_contexts; it counts against pljs.memory_limit and is
+     * not returned until the backend exits.
+     */
     if (JS_IsNull(o) || JS_IsUndefined(o)) {
       (*is_null)[c] = true;
+      JS_FreeValue(ctx, o);
       continue;
     }
 
@@ -822,6 +833,8 @@ Datum *pljs_jsvalue_to_datums(pljs_type *type, JSValue val, bool **is_null,
     // considered `NULL`.
     values[c] = pljs_jsvalue_to_datum(TupleDescAttr(tupdesc, c)->atttypid, o,
                                       &(*is_null)[c], ctx, NULL);
+
+    JS_FreeValue(ctx, o);
   }
 
   if (cleanup_tupdesc) {
@@ -872,13 +885,17 @@ Datum pljs_jsvalue_to_record(pljs_type *type, JSValue val, bool *is_null,
 
     JSValue o = JS_GetPropertyStr(ctx, val, colname);
 
+    /* Owned reference: release it on both paths.  See pljs_jsvalue_to_datums(). */
     if (JS_IsNull(o) || JS_IsUndefined(o)) {
       nulls[c] = true;
+      JS_FreeValue(ctx, o);
       continue;
     }
 
     values[c] = pljs_jsvalue_to_datum(TupleDescAttr(tupdesc, c)->atttypid, o,
                                       &nulls[c], ctx, NULL);
+
+    JS_FreeValue(ctx, o);
   }
 
   // Form a Tuple from the values and nulls using the tuple descriptor

--- a/src/types.c
+++ b/src/types.c
@@ -318,7 +318,7 @@ JSValue pljs_datum_to_object(pljs_type *type, Datum arg, JSContext *ctx) {
   PG_CATCH();
   {
     ErrorData *edata = CopyErrorData();
-    JSValue error = js_throw(edata->message, ctx);
+    JSValue error = js_throw_error_data(edata, ctx);
     FlushErrorState();
     FreeErrorData(edata);
 


### PR DESCRIPTION
Depends on #33. Until that merges, this diff also contains its commits; the commit list is the part to read.

---

`NAMEOID` was handled in the same case group as `TEXTOID`, `VARCHAROID` and
`BPCHAROID`, all of which construct a varlena. `name` is not a varlena — it is a
fixed-length `NameData` of `NAMEDATALEN` bytes with no length word. Building one as text
writes a varlena header into the first bytes of the value, and anything comparing it
against a real name reads that header as characters.

Nothing raises, which is what makes it expensive to find. The value simply never
matches:

```js
pljs.execute('SELECT nspname FROM pg_namespace WHERE nspname = $1', ['pg_catalog'])
// 0 rows

pljs.execute('SELECT $1::name::text AS t', ['hello_name'])[0].t
// '8'
```

Catalog introspection by name — `nspname`, `relname`, `typname`, `attname` — is how
most of it is written, so the blast radius is wider than the round trip suggests: any
such query silently returns nothing.

`NAMEOID` now gets its own case and goes through `namein()`, which lays the value out
correctly and applies the truncation rule at `NAMEDATALEN - 1` instead of raising. The
QuickJS string is released on the error path as well, so a value `namein()` rejects does
not leak it.

## Test plan

`sql/pg_name_bind.sql` covers a catalog lookup by name, the round trip, the empty name,
truncation of an over-long value, and returning a `name` from a function.

It discriminates: with the conversion reverted, both catalog lookups return `0` instead
of `1`, and the round trip returns `8` and `\x10` instead of the names. Full suite green
on PostgreSQL 17; builds clean on 16, 18 and 19beta3.

