### PR TITLE
Parse a JavaScript string bound to bool with the type's input function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ endif
 
 REGRESS = init-extension function json jsonb json_conv types bytea context \
 	cursor array_spread plv8_regressions memory_limits inline composites \
-	trigger procedure find_function start_proc window regressions
+	trigger procedure find_function start_proc window regressions \
+	pg_bool_string_parse
 
 all: deps/quickjs/quickjs.h deps/quickjs/libquickjs.a pljs--$(PLJS_VERSION).sql
 

--- a/expected/pg_bool_string_parse.out
+++ b/expected/pg_bool_string_parse.out
@@ -1,0 +1,101 @@
+-- A JavaScript string bound to bool is parsed, not coerced by truthiness.
+--
+-- JS_ToBool() reports every non-empty string as true, so "false", "f", "no"
+-- and "0" all became true, while "" became false. bool's input function
+-- accepts the same spellings SQL does and raises on anything else.
+--
+-- Breaking change: binding or returning the string 'false' used to store
+-- true. A real JS boolean, and the truthiness of a non-string, are unchanged.
+CREATE EXTENSION IF NOT EXISTS pljs;
+NOTICE:  extension "pljs" already exists, skipping
+-- 1) every spelling SQL accepts, in both directions.
+DO $$
+  const truthy = ['true', 't', 'TRUE', 'True', 'yes', 'y', 'on', '1', '  true  '];
+  const falsy  = ['false', 'f', 'FALSE', 'False', 'no', 'n', 'off', '0', '  false  '];
+  const bad = [];
+
+  for (const s of truthy) {
+    const v = pljs.execute('SELECT $1::bool AS v', [s])[0].v;
+    if (v !== true) { bad.push(JSON.stringify(s) + ' -> ' + v); }
+  }
+  for (const s of falsy) {
+    const v = pljs.execute('SELECT $1::bool AS v', [s])[0].v;
+    if (v !== false) { bad.push(JSON.stringify(s) + ' -> ' + v); }
+  }
+
+  pljs.elog(NOTICE, 'all bool spellings correct: ' + (bad.length === 0) +
+                    (bad.length ? ' failures: ' + bad.join(', ') : ''));
+$$ LANGUAGE pljs;
+NOTICE:  all bool spellings correct: true
+-- 2) a JS boolean stringified and bound must round-trip to itself.
+--    (needsSnapshot ? "true" : "false" is the shape that used to invert.)
+DO $$
+  for (const b of [true, false]) {
+    const s = b ? 'true' : 'false';
+    const v = pljs.execute('SELECT $1::bool AS v', [s])[0].v;
+    pljs.elog(NOTICE, 'stringified ' + s + ' -> ' + v + ' correct=' + (v === b));
+  }
+$$ LANGUAGE pljs;
+NOTICE:  stringified true -> true correct=true
+NOTICE:  stringified false -> false correct=true
+-- the SQL-side workaround (? = 'true') still agrees.
+DO $$
+  for (const s of ['true', 'false']) {
+    const v = pljs.execute('SELECT ($1 = $2) AS v', [s, 'true'])[0].v;
+    pljs.elog(NOTICE, "idiom (? = 'true') " + s + ' -> ' + v);
+  }
+$$ LANGUAGE pljs;
+NOTICE:  idiom (? = 'true') true -> true
+NOTICE:  idiom (? = 'true') false -> false
+-- 3) a bool return value, not just a bind.
+CREATE FUNCTION bsp_false_str() RETURNS bool LANGUAGE pljs AS $$ return 'false'; $$;
+CREATE FUNCTION bsp_true_str() RETURNS bool LANGUAGE pljs AS $$ return 'true'; $$;
+CREATE FUNCTION bsp_f_str() RETURNS bool LANGUAGE pljs AS $$ return 'f'; $$;
+SELECT bsp_false_str(), bsp_true_str(), bsp_f_str();
+ bsp_false_str | bsp_true_str | bsp_f_str 
+---------------+--------------+-----------
+ f             | t            | f
+(1 row)
+
+-- a bool column via return_next.
+CREATE FUNCTION bsp_col() RETURNS TABLE(flag bool, k int) LANGUAGE pljs AS $$
+  pljs.return_next({flag: 'false', k: 1});
+  pljs.return_next({flag: 'true', k: 2});
+$$;
+SELECT k, flag FROM bsp_col() ORDER BY k;
+ k | flag 
+---+------
+ 1 | f
+ 2 | t
+(2 rows)
+
+-- 4) text that is not a boolean raises instead of silently becoming true,
+--    and the empty string no longer masquerades as false.
+CREATE FUNCTION bsp_bad() RETURNS bool LANGUAGE pljs AS $$ return 'maybe'; $$;
+CREATE FUNCTION bsp_empty() RETURNS bool LANGUAGE pljs AS $$ return ''; $$;
+SELECT bsp_bad();
+ERROR:  invalid input syntax for type boolean: "maybe"
+SELECT bsp_empty();
+ERROR:  invalid input syntax for type boolean: ""
+-- 5) real JS booleans and truthiness of non-strings are unchanged.
+CREATE FUNCTION bsp_true() RETURNS bool LANGUAGE pljs AS $$ return true; $$;
+CREATE FUNCTION bsp_false() RETURNS bool LANGUAGE pljs AS $$ return false; $$;
+CREATE FUNCTION bsp_zero() RETURNS bool LANGUAGE pljs AS $$ return 0; $$;
+CREATE FUNCTION bsp_one() RETURNS bool LANGUAGE pljs AS $$ return 1; $$;
+CREATE FUNCTION bsp_obj() RETURNS bool LANGUAGE pljs AS $$ return {}; $$;
+SELECT bsp_true(), bsp_false(), bsp_zero(), bsp_one(), bsp_obj();
+ bsp_true | bsp_false | bsp_zero | bsp_one | bsp_obj 
+----------+-----------+----------+---------+---------
+ t        | f         | f        | t       | t
+(1 row)
+
+-- 6) a NULL return is still NULL.
+CREATE FUNCTION bsp_null() RETURNS bool LANGUAGE pljs AS $$ return null; $$;
+SELECT bsp_null() IS NULL AS null_ok;
+ null_ok 
+---------
+ t
+(1 row)
+
+DROP FUNCTION bsp_false_str, bsp_true_str, bsp_f_str, bsp_col, bsp_bad,
+  bsp_empty, bsp_true, bsp_false, bsp_zero, bsp_one, bsp_obj, bsp_null;

--- a/sql/pg_bool_string_parse.sql
+++ b/sql/pg_bool_string_parse.sql
@@ -1,0 +1,81 @@
+-- A JavaScript string bound to bool is parsed, not coerced by truthiness.
+--
+-- JS_ToBool() reports every non-empty string as true, so "false", "f", "no"
+-- and "0" all became true, while "" became false. bool's input function
+-- accepts the same spellings SQL does and raises on anything else.
+--
+-- Breaking change: binding or returning the string 'false' used to store
+-- true. A real JS boolean, and the truthiness of a non-string, are unchanged.
+CREATE EXTENSION IF NOT EXISTS pljs;
+
+-- 1) every spelling SQL accepts, in both directions.
+DO $$
+  const truthy = ['true', 't', 'TRUE', 'True', 'yes', 'y', 'on', '1', '  true  '];
+  const falsy  = ['false', 'f', 'FALSE', 'False', 'no', 'n', 'off', '0', '  false  '];
+  const bad = [];
+
+  for (const s of truthy) {
+    const v = pljs.execute('SELECT $1::bool AS v', [s])[0].v;
+    if (v !== true) { bad.push(JSON.stringify(s) + ' -> ' + v); }
+  }
+  for (const s of falsy) {
+    const v = pljs.execute('SELECT $1::bool AS v', [s])[0].v;
+    if (v !== false) { bad.push(JSON.stringify(s) + ' -> ' + v); }
+  }
+
+  pljs.elog(NOTICE, 'all bool spellings correct: ' + (bad.length === 0) +
+                    (bad.length ? ' failures: ' + bad.join(', ') : ''));
+$$ LANGUAGE pljs;
+
+-- 2) a JS boolean stringified and bound must round-trip to itself.
+--    (needsSnapshot ? "true" : "false" is the shape that used to invert.)
+DO $$
+  for (const b of [true, false]) {
+    const s = b ? 'true' : 'false';
+    const v = pljs.execute('SELECT $1::bool AS v', [s])[0].v;
+    pljs.elog(NOTICE, 'stringified ' + s + ' -> ' + v + ' correct=' + (v === b));
+  }
+$$ LANGUAGE pljs;
+
+-- the SQL-side workaround (? = 'true') still agrees.
+DO $$
+  for (const s of ['true', 'false']) {
+    const v = pljs.execute('SELECT ($1 = $2) AS v', [s, 'true'])[0].v;
+    pljs.elog(NOTICE, "idiom (? = 'true') " + s + ' -> ' + v);
+  }
+$$ LANGUAGE pljs;
+
+-- 3) a bool return value, not just a bind.
+CREATE FUNCTION bsp_false_str() RETURNS bool LANGUAGE pljs AS $$ return 'false'; $$;
+CREATE FUNCTION bsp_true_str() RETURNS bool LANGUAGE pljs AS $$ return 'true'; $$;
+CREATE FUNCTION bsp_f_str() RETURNS bool LANGUAGE pljs AS $$ return 'f'; $$;
+SELECT bsp_false_str(), bsp_true_str(), bsp_f_str();
+
+-- a bool column via return_next.
+CREATE FUNCTION bsp_col() RETURNS TABLE(flag bool, k int) LANGUAGE pljs AS $$
+  pljs.return_next({flag: 'false', k: 1});
+  pljs.return_next({flag: 'true', k: 2});
+$$;
+SELECT k, flag FROM bsp_col() ORDER BY k;
+
+-- 4) text that is not a boolean raises instead of silently becoming true,
+--    and the empty string no longer masquerades as false.
+CREATE FUNCTION bsp_bad() RETURNS bool LANGUAGE pljs AS $$ return 'maybe'; $$;
+CREATE FUNCTION bsp_empty() RETURNS bool LANGUAGE pljs AS $$ return ''; $$;
+SELECT bsp_bad();
+SELECT bsp_empty();
+
+-- 5) real JS booleans and truthiness of non-strings are unchanged.
+CREATE FUNCTION bsp_true() RETURNS bool LANGUAGE pljs AS $$ return true; $$;
+CREATE FUNCTION bsp_false() RETURNS bool LANGUAGE pljs AS $$ return false; $$;
+CREATE FUNCTION bsp_zero() RETURNS bool LANGUAGE pljs AS $$ return 0; $$;
+CREATE FUNCTION bsp_one() RETURNS bool LANGUAGE pljs AS $$ return 1; $$;
+CREATE FUNCTION bsp_obj() RETURNS bool LANGUAGE pljs AS $$ return {}; $$;
+SELECT bsp_true(), bsp_false(), bsp_zero(), bsp_one(), bsp_obj();
+
+-- 6) a NULL return is still NULL.
+CREATE FUNCTION bsp_null() RETURNS bool LANGUAGE pljs AS $$ return null; $$;
+SELECT bsp_null() IS NULL AS null_ok;
+
+DROP FUNCTION bsp_false_str, bsp_true_str, bsp_f_str, bsp_col, bsp_bad,
+  bsp_empty, bsp_true, bsp_false, bsp_zero, bsp_one, bsp_obj, bsp_null;

--- a/src/types.c
+++ b/src/types.c
@@ -880,6 +880,58 @@ static Datum pljs_jsvalue_to_datum_fallback(JSValue value, bool *is_null,
 }
 
 /**
+ * @brief Parse a JavaScript string with a PostgreSQL type's input function.
+ *
+ * QuickJS's numeric/boolean coercions do not parse SQL text: JS_ToBool()
+ * treats every non-empty string as true, and the numeric conversions go
+ * through an IEEE-754 double. The input function reads the text exactly
+ * as a SQL literal of that type would, and raises on anything it cannot
+ * accept. That is also what plv8 does.
+ *
+ * @param typid #Oid - target type
+ * @param val #JSValue - the JavaScript string to parse
+ * @param ctx #JSContext - Javascript context to execute in
+ * @returns #Datum parsed from the string
+ */
+static Datum pljs_string_to_datum_via_input(Oid typid, JSValueConst val,
+                                            JSContext *ctx) {
+  size_t plen;
+  const char *str = JS_ToCStringLen(ctx, &plen, val);
+  Oid typinput, typioparam;
+  Datum ret;
+
+  if (str == NULL) {
+    elog(ERROR, "could not convert JavaScript value to a string");
+  }
+
+  if (memchr(str, '\0', plen) != NULL) {
+    JS_FreeCString(ctx, str);
+    ereport(ERROR,
+            (errcode(ERRCODE_UNTRANSLATABLE_CHARACTER),
+             errmsg("null byte (\\u0000) is not allowed in a value of type %s",
+                    format_type_be(typid))));
+  }
+
+  getTypeInputInfo(typid, &typinput, &typioparam);
+
+  PG_TRY();
+  {
+    ret = OidInputFunctionCall(typinput, (char *)str, typioparam, -1);
+  }
+  PG_CATCH();
+  {
+    /* Do not leak the QuickJS C-string when the input function rejects it. */
+    JS_FreeCString(ctx, str);
+    PG_RE_THROW();
+  }
+  PG_END_TRY();
+
+  JS_FreeCString(ctx, str);
+
+  return ret;
+}
+
+/**
  * @brief Converts a Javascript value to a Postgres #Datum.
  *
  * Takes a Javascript value and converts it into a Postgres #Datum,
@@ -942,6 +994,21 @@ Datum pljs_jsvalue_to_datum(Oid rettype, JSValue val, bool *is_null,
   }
 
   case BOOLOID: {
+    /*
+     * A string is parsed by bool's input function, not coerced with
+     * JS_ToBool(). JS_ToBool() reports every non-empty string as true, so
+     * "false", "f", "no" and "0" all became true while "" became false —
+     * the opposite of what the text means. The input function accepts
+     * exactly what SQL accepts and raises on anything else.
+     *
+     * This is a behaviour change: a bind or return of the string "false"
+     * used to store true. A JavaScript boolean, and the truthiness of any
+     * non-string, are untouched.
+     */
+    if (JS_IsString(val)) {
+      return pljs_string_to_datum_via_input(BOOLOID, val, ctx);
+    }
+
     int8_t in = JS_ToBool(ctx, val);
     PG_RETURN_BOOL(in);
     break;


### PR DESCRIPTION
A JavaScript string bound to — or returned as — `bool` was handed to `JS_ToBool()`, which reports every non-empty string as true. The text then meant the opposite of what was stored:

```
'false' / 'f' / 'no' / '0'   ->  true
''                           ->  false
'true'                       ->  true   (accidentally correct)
```

The string is now parsed by bool's input function, which accepts the same spellings SQL does (`true`/`false`, `t`/`f`, `yes`/`no`, `on`/`off`, `1`/`0`, any case, optional whitespace) and raises on anything else. **This is also what plv8 does.** A real JavaScript boolean, and the truthiness of a non-string (`0`, `1`, `{}`), are unchanged.

## The behaviour change, stated plainly

| | before | after |
|---|---|---|
| `return 'false'` | `true` | `false` |
| `return 'maybe'` | `true` | `ERROR: invalid input syntax for type boolean: "maybe"` |
| `return ''` | `false` | `ERROR: invalid input syntax for type boolean: ""` |
| `return false` | `false` | `false` (unchanged) |
| `return 0` | `false` | `false` (unchanged) |

Anyone who bound a stringified flag (`needsSnapshot ? "true" : "false"`) was writing `true` on every path. That is the wart this removes. It is a breaking change for anyone who relied on the old truthiness; there is no better time than before this hardens further.

## Test plan

`sql/pg_bool_string_parse.sql` covers SQL's accepted spellings in both directions, a stringified true/false round-trip, the raise for non-boolean text and the empty string, that JS booleans and non-string truthiness are untouched, and that a NULL return is still NULL. With the conversion reverted, `'false'` comes back as `true` and `'maybe'` does not raise.

Built and passed the full suite locally on PostgreSQL 18.1.


Made with [Cursor](https://cursor.com)